### PR TITLE
Add fastutil to dependencies.gradle

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,8 @@
 // Add your dependencies here
 
 dependencies {
+    shadowImplementation("it.unimi.dsi:fastutil:8.5.12") // Apache 2.0
+    
     testImplementation(platform("org.junit:junit-bom:5.9.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher") {
@@ -12,7 +14,6 @@ dependencies {
     compileOnly('org.jetbrains:annotations:24.0.1')
     compileOnly("org.projectlombok:lombok:1.18.22") {transitive = false }
     annotationProcessor("org.projectlombok:lombok:1.18.22")
-
 }
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -69,7 +69,9 @@ forceEnableMixins = false
 
 # If enabled, you may use 'shadowCompile' for dependencies. They will be integrated in your jar. It is your
 # responsibility check the licence and request permission for distribution, if required.
-usesShadowedDependencies = false
+usesShadowedDependencies = true
+relocateShadowedDependencies = false
+minimizeShadowedDependencies = false
 
 # Optional parameter to customize the produced artifacts. Use this to preserver artifact naming when migrating older
 # projects. New projects should not use this parameter.


### PR DESCRIPTION
Already used in Angelica, although it can be minimized there. This way it can be re-used everywhere though.
Bloats the file size from 50kb to 22MB 💀 