### PR TITLE
Fix lower bound of `@Config.RangeFloat`

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/Config.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/Config.java
@@ -66,7 +66,7 @@ public @interface Config {
     @Target(ElementType.FIELD)
     @interface RangeFloat {
 
-        float min() default Float.MIN_VALUE;
+        float min() default -Float.MAX_VALUE;
 
         float max() default Float.MAX_VALUE;
     }


### PR DESCRIPTION
Unlike `Integer.MIN_VALUE`, `Float.MIN_VALUE` is actually the smallest, positive non-zero number (2<sup>-149</sup>).