### PR TITLE
Add the MixinCompatHackTweaker to fix running on java 8 w/o lwjgl3ify/rfbplugin

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
@@ -6,7 +6,9 @@ import java.util.Set;
 
 import net.minecraft.launchwrapper.Launch;
 
-import com.gtnewhorizon.gtnhlib.core.transformer.TessellatorRedirectorTransformer;
+import org.spongepowered.asm.launch.GlobalProperties;
+import org.spongepowered.asm.service.mojang.MixinServiceLaunchWrapper;
+
 import com.gtnewhorizon.gtnhlib.mixins.Mixins;
 import com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader;
 
@@ -22,17 +24,17 @@ public class GTNHLibCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
 
     @Override
     public String[] getASMTransformerClass() {
-        if (FMLLaunchHandler.side().isClient()) {
-            final boolean rfbLoaded = Launch.blackboard.getOrDefault("gtnhlib.rfbPluginLoaded", Boolean.FALSE)
-                    == Boolean.TRUE;
-            if (!rfbLoaded) {
-                System.out.println("GTNHLib: RFB plugin not loaded, loading ASM transformer");
-                return new String[] { TessellatorRedirectorTransformer.class.getName() };
-            } else {
-                System.out.println("GTNHLib: RFB plugin loaded, skipping ASM transformer");
-            }
+        if (!FMLLaunchHandler.side().isClient()
+                || Launch.blackboard.getOrDefault("gtnhlib.rfbPluginLoaded", Boolean.FALSE) == Boolean.TRUE) {
+            // Don't need any transformers if we're not on the client, or the RFB Plugin was loaded
+            return new String[0];
         }
-        return null;
+        // Directly add this to the MixinServiceLaunchWrapper tweaker's list of Tweak Classes
+        List<String> mixinTweakClasses = GlobalProperties.get(MixinServiceLaunchWrapper.BLACKBOARD_KEY_TWEAKCLASSES);
+        if (mixinTweakClasses != null) {
+            mixinTweakClasses.add(MixinCompatHackTweaker.class.getName());
+        }
+        return new String[0];
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/gtnhlib/core/MixinCompatHackTweaker.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/core/MixinCompatHackTweaker.java
@@ -1,0 +1,45 @@
+package com.gtnewhorizon.gtnhlib.core;
+
+import java.io.File;
+import java.util.List;
+
+import net.minecraft.launchwrapper.ITweaker;
+import net.minecraft.launchwrapper.Launch;
+import net.minecraft.launchwrapper.LaunchClassLoader;
+
+import com.gtnewhorizon.gtnhlib.core.transformer.TessellatorRedirectorTransformer;
+
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
+
+public class MixinCompatHackTweaker implements ITweaker {
+
+    @Override
+    public void acceptOptions(List<String> args, File gameDir, File assetsDir, String profile) {
+        // no-op
+    }
+
+    @Override
+    public void injectIntoClassLoader(LaunchClassLoader classLoader) {
+        // no-op
+    }
+
+    @Override
+    public String getLaunchTarget() {
+        return null;
+    }
+
+    @Override
+    public String[] getLaunchArguments() {
+        if (FMLLaunchHandler.side().isClient()) {
+            final boolean rfbLoaded = Launch.blackboard.getOrDefault("gtnhlib.rfbPluginLoaded", Boolean.FALSE)
+                    == Boolean.TRUE;
+
+            if (!rfbLoaded) {
+                // Run after Mixins, but before LWJGl3ify
+                Launch.classLoader.registerTransformer(TessellatorRedirectorTransformer.class.getName());
+            }
+        }
+
+        return new String[0];
+    }
+}


### PR DESCRIPTION
Tested w/ java 8 & Angelica beta 4


```
angelica-1.0.0-beta4.jar
archaicfix-0.7.0.jar
CodeChickenCore-1.3.6.jar
CoreTweaks-1.7.10-0.3.3.2+nomixin.jar
gtnhlib-0.4.2.jar
NotEnoughItems-2.6.19-GTNH.jar
+unimixins-all-1.7.10-0.1.15.jar
```