### PR TITLE
Vertex Normals for the capturing tesselator

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/FaceBehaviorManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/FaceBehaviorManager.java
@@ -1,0 +1,22 @@
+package com.gtnewhorizon.gtnhlib.client.renderer;
+
+public class FaceBehaviorManager {
+
+    // ThreadLocal instance to hold the behavior flag for each thread
+    private static final ThreadLocal<Boolean> captureVertexNormals = ThreadLocal.withInitial(() -> false);
+
+    // Method to set the behavior flag
+    public static void setVertexNormalBehavior(boolean flag) {
+        captureVertexNormals.set(flag);
+    }
+
+    // Method to get the behavior flag
+    public static boolean getVertexNormalBehavior() {
+        return captureVertexNormals.get();
+    }
+
+    // Method to clear the behavior flag
+    public static void clearVertexNormalBehavior() {
+        captureVertexNormals.remove();
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/vbo/IModelCustomExt.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/vbo/IModelCustomExt.java
@@ -13,4 +13,7 @@ public interface IModelCustomExt extends IModelCustom {
 
     @SideOnly(CLIENT)
     void renderAllVBO();
+
+    @SideOnly(CLIENT)
+    void captureVertexNormals(boolean flag);
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -17,7 +17,9 @@ public enum Mixins {
     TESSELLATOR(new Builder("Sodium").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT).setPhase(Phase.EARLY)
             .setApplyIf(() -> true).addMixinClasses("MixinTessellator")),
     WAVEFRONT_VBO(new Builder("WavefrontObject").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)
-            .setPhase(Phase.EARLY).setApplyIf(() -> true).addMixinClasses("MixinWavefrontObject")),;
+            .setPhase(Phase.EARLY).setApplyIf(() -> true).addMixinClasses("MixinWavefrontObject")),
+    FACE(new Builder("Face").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT).setPhase(Phase.EARLY)
+            .setApplyIf(() -> true).addMixinClasses("MixinFace")),;
 
     private final List<String> mixinClasses;
     private final Supplier<Boolean> applyIf;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinFace.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinFace.java
@@ -36,7 +36,6 @@ public abstract class MixinFace {
             at = @At("HEAD"),
             cancellable = true)
     private void onAddFaceForRender(Tessellator tessellator, float textureOffset, CallbackInfo ci) {
-        System.out.println("Hijack");
         if (FaceBehaviorManager.getVertexNormalBehavior()) {
             if (faceNormal == null) {
                 faceNormal = this.calculateFaceNormal();
@@ -60,7 +59,6 @@ public abstract class MixinFace {
 
             for (int i = 0; i < vertices.length; ++i) {
                 if ((vertexNormals != null) && (vertexNormals.length > 0)) {
-                    System.out.println("PRINTING");
                     tessellator.setNormal(vertexNormals[i].x, vertexNormals[i].y, vertexNormals[i].z);
                 }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinFace.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinFace.java
@@ -31,8 +31,9 @@ public abstract class MixinFace {
     @Shadow
     public abstract Vertex calculateFaceNormal();
 
-    @Inject(method = "addFaceForRender", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "addFaceForRender(Lnet/minecraft/client/renderer/Tessellator;F)V", at = @At("HEAD"), cancellable = true)
     private void onAddFaceForRender(Tessellator tessellator, float textureOffset, CallbackInfo ci) {
+        System.out.println("Hijack");
         if (FaceBehaviorManager.getVertexNormalBehavior()) {
             if (faceNormal == null) {
                 faceNormal = this.calculateFaceNormal();
@@ -56,6 +57,7 @@ public abstract class MixinFace {
 
             for (int i = 0; i < vertices.length; ++i) {
                 if ((vertexNormals != null) && (vertexNormals.length > 0)) {
+                    System.out.println("PRINTING");
                     tessellator.setNormal(vertexNormals[i].x, vertexNormals[i].y, vertexNormals[i].z);
                 }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinFace.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinFace.java
@@ -1,0 +1,87 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraftforge.client.model.obj.Face;
+import net.minecraftforge.client.model.obj.TextureCoordinate;
+import net.minecraftforge.client.model.obj.Vertex;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizon.gtnhlib.client.renderer.FaceBehaviorManager;
+
+@Mixin(value = Face.class, remap = false)
+public abstract class MixinFace {
+
+    @Shadow
+    private Vertex[] vertices;
+
+    @Shadow
+    private Vertex[] vertexNormals;
+
+    @Shadow
+    private Vertex faceNormal;
+
+    @Shadow
+    private TextureCoordinate[] textureCoordinates;
+
+    @Shadow
+    public abstract Vertex calculateFaceNormal();
+
+    @Inject(method = "addFaceForRender", at = @At("HEAD"), cancellable = true)
+    private void onAddFaceForRender(Tessellator tessellator, float textureOffset, CallbackInfo ci) {
+        if (FaceBehaviorManager.getVertexNormalBehavior()) {
+            if (faceNormal == null) {
+                faceNormal = this.calculateFaceNormal();
+            }
+            tessellator.setNormal(faceNormal.x, faceNormal.y, faceNormal.z);
+
+            float averageU = 0F;
+            float averageV = 0F;
+
+            if ((textureCoordinates != null) && (textureCoordinates.length > 0)) {
+                for (int i = 0; i < textureCoordinates.length; ++i) {
+                    averageU += textureCoordinates[i].u;
+                    averageV += textureCoordinates[i].v;
+                }
+
+                averageU = averageU / textureCoordinates.length;
+                averageV = averageV / textureCoordinates.length;
+            }
+
+            float offsetU, offsetV;
+
+            for (int i = 0; i < vertices.length; ++i) {
+                if ((vertexNormals != null) && (vertexNormals.length > 0)) {
+                    tessellator.setNormal(vertexNormals[i].x, vertexNormals[i].y, vertexNormals[i].z);
+                }
+
+                if ((textureCoordinates != null) && (textureCoordinates.length > 0)) {
+                    offsetU = textureOffset;
+                    offsetV = textureOffset;
+
+                    if (textureCoordinates[i].u > averageU) {
+                        offsetU = -offsetU;
+                    }
+                    if (textureCoordinates[i].v > averageV) {
+                        offsetV = -offsetV;
+                    }
+
+                    tessellator.addVertexWithUV(
+                            vertices[i].x,
+                            vertices[i].y,
+                            vertices[i].z,
+                            textureCoordinates[i].u + offsetU,
+                            textureCoordinates[i].v + offsetV);
+                } else {
+                    tessellator.addVertex(vertices[i].x, vertices[i].y, vertices[i].z);
+                }
+            }
+
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinFace.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinFace.java
@@ -31,7 +31,10 @@ public abstract class MixinFace {
     @Shadow
     public abstract Vertex calculateFaceNormal();
 
-    @Inject(method = "addFaceForRender(Lnet/minecraft/client/renderer/Tessellator;F)V", at = @At("HEAD"), cancellable = true)
+    @Inject(
+            method = "addFaceForRender(Lnet/minecraft/client/renderer/Tessellator;F)V",
+            at = @At("HEAD"),
+            cancellable = true)
     private void onAddFaceForRender(Tessellator tessellator, float textureOffset, CallbackInfo ci) {
         System.out.println("Hijack");
         if (FaceBehaviorManager.getVertexNormalBehavior()) {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinWavefrontObject.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinWavefrontObject.java
@@ -64,7 +64,7 @@ public abstract class MixinWavefrontObject implements IModelCustomExt {
         vertexBuffer.render();
     }
 
-    @Unique
+    @Override
     public void captureVertexNormals(boolean flag) {
         captureVertexNormalsFlag = flag;
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinWavefrontObject.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinWavefrontObject.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 
 import com.gtnewhorizon.gtnhlib.client.renderer.CapturingTessellator;
+import com.gtnewhorizon.gtnhlib.client.renderer.FaceBehaviorManager;
 import com.gtnewhorizon.gtnhlib.client.renderer.TessellatorManager;
 import com.gtnewhorizon.gtnhlib.client.renderer.vbo.IModelCustomExt;
 import com.gtnewhorizon.gtnhlib.client.renderer.vbo.VertexBuffer;
@@ -30,6 +31,9 @@ public abstract class MixinWavefrontObject implements IModelCustomExt {
     @Unique
     VertexFormat format = DefaultVertexFormat.POSITION_TEXTURE_NORMAL;
 
+    @Unique
+    boolean captureVertexNormalsFlag = false;
+
     @Override
     public void rebuildVBO() {
         if (currentGroupObject == null) {
@@ -38,12 +42,18 @@ public abstract class MixinWavefrontObject implements IModelCustomExt {
         if (this.vertexBuffer != null) {
             this.vertexBuffer.close();
         }
+
+        if (captureVertexNormalsFlag) FaceBehaviorManager.setVertexNormalBehavior(true);
+
         TessellatorManager.startCapturing();
         final CapturingTessellator tess = (CapturingTessellator) TessellatorManager.get();
         tess.startDrawing(currentGroupObject.glDrawingMode);
         tessellateAll(tess);
 
         this.vertexBuffer = TessellatorManager.stopCapturingToVBO(format);
+
+        FaceBehaviorManager.clearVertexNormalBehavior();
+
     }
 
     @Override
@@ -53,4 +63,10 @@ public abstract class MixinWavefrontObject implements IModelCustomExt {
         }
         vertexBuffer.render();
     }
+
+    @Unique
+    public void captureVertexNormals(boolean flag) {
+        captureVertexNormalsFlag = flag;
+    }
+
 }


### PR DESCRIPTION
With this the capturing tesselator can be used to upload vertex normals to render out.

I'm not sure if the captureVertexNormals should be settable in the tesselator or the Wavemodel Mixim, but the former seemed easier to leak the flag after use.  If there's a solution without a threadlocal flag I'd like to see how I'd avoid them.
