### PR TITLE
Fix a few config issues

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/Config.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/Config.java
@@ -49,7 +49,8 @@ public @interface Config {
      * {@code %field} - field name <b>(required)</b> <br>
      * </p>
      * Default pattern: {@code %mod.%cat.%field}. Categories use the pattern without {@code %field}. Can be overridden
-     * for fields with {@link Config.LangKey}.
+     * for fields with {@link Config.LangKey}. <br>
+     * The generated keys can be printed to log by setting the {@code -Dgtnhlib.printkeys=true} JVM flag.
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)

--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/Config.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/Config.java
@@ -67,7 +67,7 @@ public @interface Config {
     }
 
     @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.FIELD)
+    @Target({ ElementType.FIELD, ElementType.TYPE })
     @interface Comment {
 
         String[] value();

--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigFieldParser.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigFieldParser.java
@@ -445,7 +445,7 @@ public class ConfigFieldParser {
                 stringValues[i] = Double.toString(defaultValue[i]);
             }
             comment = comment + " [default: " + Arrays.toString(stringValues) + "]";
-            double[] value = config.get(category, name, defaultValue, comment).getDoubleList();
+            double[] value = config.get(category, name, defaultValue, comment).setLanguageKey(langKey).getDoubleList();
 
             field.set(instance, value);
         }
@@ -484,7 +484,7 @@ public class ConfigFieldParser {
                 stringValues[i] = Integer.toString(defaultValue[i]);
             }
             comment = comment + " [default: " + Arrays.toString(stringValues) + "]";
-            int[] value = config.get(category, name, defaultValue, comment).getIntList();
+            int[] value = config.get(category, name, defaultValue, comment).setLanguageKey(langKey).getIntList();
 
             field.set(instance, value);
         }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
@@ -132,16 +132,15 @@ public class ConfigurationManager {
 
     private static void processSubCategory(Object instance, Configuration config, Field subCategoryField,
             String category) throws ConfigException {
-        var comment = Optional.ofNullable(subCategoryField.getAnnotation(Config.Comment.class))
-                .map(Config.Comment::value).map((lines) -> String.join("\n", lines)).orElse("");
         val name = ConfigFieldParser.getFieldName(subCategoryField);
         val cat = (category.isEmpty() ? "" : category + Configuration.CATEGORY_SPLITTER) + name.toLowerCase();
         ConfigCategory subCat = config.getCategory(cat);
-        val langKey = Optional.ofNullable(subCategoryField.getAnnotation(Config.LangKey.class))
-                .map(Config.LangKey::value).orElse(subCat.getName());
 
-        subCat.setComment(comment);
-        subCat.setLanguageKey(langKey);
+        Optional.ofNullable(subCategoryField.getAnnotation(Config.Comment.class)).map(Config.Comment::value)
+                .map((lines) -> String.join("\n", lines)).ifPresent(subCat::setComment);
+        Optional.ofNullable(subCategoryField.getAnnotation(Config.LangKey.class)).map(Config.LangKey::value)
+                .ifPresent(subCat::setLanguageKey);
+
         if (subCategoryField.isAnnotationPresent(Config.RequiresMcRestart.class)) {
             subCat.setRequiresMcRestart(true);
         }
@@ -228,6 +227,9 @@ public class ConfigurationManager {
         }
         cat.setRequiresMcRestart(requiresMcRestart);
         cat.setRequiresWorldRestart(requiresWorldRestart);
+
+        Optional.ofNullable(configClass.getAnnotation(Config.Comment.class)).map(Config.Comment::value)
+                .map((lines) -> String.join("\n", lines)).ifPresent(cat::setComment);
     }
 
     /**


### PR DESCRIPTION
1. Fixes subcats having their category name twice in the langkey & stops subcats from having their lang key set multiple times.
2. Makes `@Config.Comment` applicable to classes so that you can put the annotation on the subcat class instead of their field & add comments for non-subcategories
3. Adds the `-Dgtnhlib.printkeys` jvm flag to print lang keys generated from `@Config.LangKeyPattern` in the log. 