### PR TITLE
Add jvm flag to dump generated lang keys to file

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.IChatComponent;
 import net.minecraftforge.common.util.FakePlayer;
 
+import com.gtnewhorizon.gtnhlib.config.ConfigurationManager;
 import com.gtnewhorizon.gtnhlib.network.NetworkHandler;
 import com.gtnewhorizon.gtnhlib.network.PacketMessageAboveHotbar;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
@@ -24,6 +24,7 @@ public class CommonProxy {
 
     public void init(FMLInitializationEvent event) {
         NetworkHandler.init();
+        ConfigurationManager.onInit();
     }
 
     public void postInit(FMLPostInitializationEvent event) {}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/Config.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/Config.java
@@ -50,7 +50,8 @@ public @interface Config {
      * </p>
      * Default pattern: {@code %mod.%cat.%field}. Categories use the pattern without {@code %field}. Can be overridden
      * for fields with {@link Config.LangKey}. <br>
-     * The generated keys can be printed to log by setting the {@code -Dgtnhlib.printkeys=true} JVM flag.
+     * The generated keys can be printed to log by setting the {@code -Dgtnhlib.printkeys=true} JVM flag or dumped to a
+     * file in the base minecraft directory by setting the {@code -Dgtnhlib.dumpkeys=true} JVM flag.
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)

--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
@@ -456,7 +456,7 @@ public class ConfigurationManager {
 
     private static void writeLangKeysToFile() {
         for (Map.Entry<String, List<String>> entry : generatedLangKeys.entrySet()) {
-            val langFile = new File("generated_keys_" + entry.getKey() + ".txt");
+            val langFile = new File("generated-lang-keys", entry.getKey() + ".txt");
             try {
                 FileUtils.writeLines(langFile, entry.getValue());
             } catch (IOException e) {


### PR DESCRIPTION
Adds the `-Dgtnhlib.dumpkeys` jvm flag to dump the lang keys generated from LangKeyPattern to a text file in a ready to copy format like so:
```
gtnhlib.test.subconfig.subsubconfig.nestednestedint=
gtnhlib.test.subconfig.subsubconfig=
gtnhlib.test.subconfig.nestedint=
gtnhlib.test.subconfig.testenum2=
gtnhlib.test.subconfig=
gtnhlib.test.testenum=
gtnhlib.test=
```