### PR TITLE
Auto remove dead config categories/values from the config file

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
@@ -47,12 +47,14 @@ public class ConfigurationManager {
     private static final Boolean PRINT_KEYS = Boolean.getBoolean("gtnhlib.printkeys");
     private static final Boolean DUMP_KEYS = Boolean.getBoolean("gtnhlib.dumpkeys");
     private static final Map<String, List<String>> generatedLangKeys = new HashMap<>();
+    private static final Map<Configuration, Set<String>> observedCategories = new HashMap<>();
 
     private static final ConfigurationManager instance = new ConfigurationManager();
+    private final static Path configDir;
 
-    private static boolean initialized = false;
-
-    private static Path configDir;
+    static {
+        configDir = minecraftHome().toPath().resolve("config");
+    }
 
     /**
      * Registers a configuration class to be loaded. This should be done before or during preInit.
@@ -60,7 +62,6 @@ public class ConfigurationManager {
      * @param configClass The class to register.
      */
     public static void registerConfig(Class<?> configClass) throws ConfigException {
-        init();
         val cfg = Optional.ofNullable(configClass.getAnnotation(Config.class)).orElseThrow(
                 () -> new ConfigException("Class " + configClass.getName() + " does not have a @Config annotation!"));
         val category = cfg.category().trim().toLowerCase();
@@ -171,6 +172,7 @@ public class ConfigurationManager {
         boolean requiresWorldRestart = getClassOrBaseAnnotation(configClass, Config.RequiresWorldRestart.class) != null
                 || foundCategory && cat.requiresWorldRestart();
 
+        List<String> observedValues = new ArrayList<>();
         for (val field : configClass.getDeclaredFields()) {
             if (field.isAnnotationPresent(Config.Ignore.class)) {
                 continue;
@@ -204,12 +206,10 @@ public class ConfigurationManager {
 
             if (category.isEmpty()) continue;
 
-            val langKey = getLangKey(
-                    configClass,
-                    field.getAnnotation(Config.LangKey.class),
-                    ConfigFieldParser.getFieldName(field),
-                    cat);
+            val fieldName = ConfigFieldParser.getFieldName(field);
+            val langKey = getLangKey(configClass, field.getAnnotation(Config.LangKey.class), fieldName, cat);
             ConfigFieldParser.loadField(instance, field, rawConfig, category, langKey);
+            observedValues.add(fieldName);
 
             if (!requiresMcRestart) {
                 requiresMcRestart = field.isAnnotationPresent(Config.RequiresMcRestart.class);
@@ -225,12 +225,20 @@ public class ConfigurationManager {
         }
 
         if (category.isEmpty()) return;
+
+        if (cat.keySet().size() != observedValues.size()) {
+            val properties = new ArrayList<>(cat.keySet());
+            properties.removeIf(observedValues::contains);
+            properties.forEach(cat::remove);
+        }
+
         if (cat.getLanguagekey().equals(category)) {
             val langKey = getLangKey(configClass, configClass.getAnnotation(Config.LangKey.class), null, cat);
             cat.setLanguageKey(langKey);
         }
         cat.setRequiresMcRestart(requiresMcRestart);
         cat.setRequiresWorldRestart(requiresWorldRestart);
+        observedCategories.computeIfAbsent(rawConfig, k -> new HashSet<>()).add(cat.getQualifiedName());
 
         Optional.ofNullable(configClass.getAnnotation(Config.Comment.class)).map(Config.Comment::value)
                 .map((lines) -> String.join("\n", lines)).ifPresent(cat::setComment);
@@ -258,7 +266,6 @@ public class ConfigurationManager {
     @SuppressWarnings("rawtypes")
     public static List<IConfigElement> getConfigElements(Class<?> configClass, boolean categorized)
             throws ConfigException {
-        init();
         val cfg = Optional.ofNullable(configClass.getAnnotation(Config.class)).orElseThrow(
                 () -> new ConfigException("Class " + configClass.getName() + " does not have a @Config annotation!"));
         val rawConfig = Optional.ofNullable(configs.get(getConfigKey(cfg))).map(
@@ -440,15 +447,8 @@ public class ConfigurationManager {
         return Launch.minecraftHome != null ? Launch.minecraftHome : new File(".");
     }
 
-    private static void init() {
-        if (initialized) {
-            return;
-        }
-        configDir = minecraftHome().toPath().resolve("config");
-        initialized = true;
-    }
-
     public static void onInit() {
+        cullDeadCategories();
         if (DUMP_KEYS) {
             writeLangKeysToFile();
         }
@@ -467,5 +467,33 @@ public class ConfigurationManager {
                         e);
             }
         }
+    }
+
+    private static void cullDeadCategories() {
+        for (val entry : observedCategories.entrySet()) {
+            val config = entry.getKey();
+            val observedCategoryNames = entry.getValue();
+
+            if (config.getCategoryNames().size() == observedCategoryNames.size()) {
+                continue;
+            }
+
+            val savedCategoryNames = new ArrayList<>(config.getCategoryNames());
+            savedCategoryNames.removeIf(observedCategoryNames::contains);
+
+            // Only keep the top-level category that needs removal otherwise getCategory() for any subcategory will
+            // recreate it.
+            List<String> parentsToRemove = savedCategoryNames.stream()
+                    .filter(s -> savedCategoryNames.stream().noneMatch(existing -> s.startsWith(existing + ".")))
+                    .collect(Collectors.toList());
+
+            for (val category : parentsToRemove) {
+                ConfigCategory cat = config.getCategory(category);
+                config.removeCategory(cat);
+            }
+
+            config.save();
+        }
+        observedCategories.clear();
     }
 }


### PR DESCRIPTION
Any config values that are no longer in use will stay indefinitely in the config file and also shows up in the config gui.
Take this old boubou test config for instance

```
# Configuration file

Test {

    subconfig {

        subsubconfig {
        }

    }

}


rossruinsmeta {
}


test {
    B:testBool=true
    D:testDouble=1.0

    # 
    # Possible values: [VALUE1, VALUE2, VALUE3, VALUE4]
    #  [default: VALUE1]
    S:testEnum=VALUE1
    I:testInt=1
    S:testString=test

    ##########################################################################################################
    # subconfig
    #--------------------------------------------------------------------------------------------------------#
    # This is a test comment
    # It spans multiple lines
    ##########################################################################################################

    subconfig {
        #  [range: -2147483648 ~ 2147483647, default: 2]
        I:nestedInt=2

        # 
        # Possible values: [VALUE1, VALUE2, VALUE3, VALUE4]
        #  [default: VALUE2]
        S:testEnum2=VALUE2

        ##########################################################################################################
        # subsubconfig
        #--------------------------------------------------------------------------------------------------------#
        # This is a test comment
        ##########################################################################################################

        subsubconfig {
            #  [range: -2147483648 ~ 2147483647, default: 3]
            I:nestedNestedInt=3
        }

    }

    rossruinmetas {

        highpressuresteam {
            I:buffers <
                5133
                5123
             >
            I:cables <
                5133
                5123
             >
            I:generators <
                100
                101
                102
                105
             >
            I:machines <
                103
                104
                106
                107
                109
                110
                112
                113
                115
                116
                118
                119
             >
        }

        lv {
            I:buffers <
                161
                171
                181
                191
             >
            I:cables <
                1210
                1230
                1250
                1270
                1290
             >
            I:generators <
                1110
                1115
                1120
                1127
             >
            I:machines <
                201
                211
                221
                231
                241
                251
                261
                271
                281
                291
                301
                311
                321
                331
                341
                351
                361
                371
                381
                391
                401
                411
                421
                431
                441
                451
                461
                471
                481
                491
                501
                511
                521
                531
                541
                551
                561
                571
                581
                591
                601
                611
                621
                631
                641
                651
                661
                671
             >
        }

        mv {
            I:buffers <
                162
                172
                182
                192
             >
            I:cables <
                1310
                1330
                1350
                1370
                1390
             >
            I:generators <
                1111
                12726
                1116
                1121
                1128
             >
            I:machines <
                202
                212
                222
                232
                242
                252
                262
                272
                282
                292
                302
                312
                322
                332
                342
                352
                362
                372
                382
                392
                402
                412
                422
                432
                442
                452
                462
                472
                482
                492
                502
                512
                522
                532
                542
                552
                562
                572
                582
                592
                602
                612
                622
                632
                642
                652
                662
                672
             >
        }

        hv {
            I:buffers <
                163
                173
                183
                193
             >
            I:cables <
                1410
                1430
                1450
                1470
                1490
             >
            I:generators <
                1112
                12727
                1117
                1122
                1129
             >
            I:machines <
                203
                213
                223
                233
                243
                253
                263
                273
                283
                293
                303
                313
                323
                333
                343
                353
                363
                373
                383
                393
                403
                413
                423
                433
                443
                453
                463
                473
                483
                493
                503
                513
                523
                533
                543
                553
                563
                573
                583
                593
                603
                613
                623
                633
                643
                653
                663
                673
             >
        }

        ev {
            I:buffers <
                164
                174
                184
                194
             >
            I:cables <
                1510
                1530
                1550
                1570
                1590
             >
            I:generators <
                12728
                1190
                1130
                12685
             >
            I:machines <
                204
                214
                224
                234
                244
                254
                264
                274
                284
                294
                304
                314
                324
                334
                344
                354
                364
                374
                384
                394
                404
                414
                424
                434
                444
                454
                464
                474
                484
                494
                504
                514
                524
                534
                544
                554
                564
                574
                584
                594
                604
                614
                624
                634
                644
                654
                664
                674
             >
        }

    }

}
```
Anything that doesn't have a comment above it is dead i.e no longer in use. This can easily confuse players and that confusion is heightened when the gui shows something like this
![nhlib_conf](https://github.com/user-attachments/assets/fc4c35a0-135e-4315-93e2-7030da48eedb)
Only the highlighted value is still active the other 4 are just dead weight, but the player can't be expected to know that.

This pr automatically gets rid of all those unnecessary values/categories, it only adds a tiny amount of overhead for configs that don't need to have anything removed as it only ends up being a size comparison for them.

The `init` method has also been moved into a static block as that works perfectly fine even for mods like Hodgepodge that register its configs very early in coremod.
 
That old config gets slimmed down to this afterwards
```
# Configuration file

test {
    # 
    # Possible values: [VALUE1, VALUE2, VALUE3, VALUE4]
    #  [default: VALUE1]
    S:testEnum=VALUE1

    ##########################################################################################################
    # subconfig
    #--------------------------------------------------------------------------------------------------------#
    # This is a test comment
    # It spans multiple lines
    ##########################################################################################################

    subconfig {
        #  [range: -2147483648 ~ 2147483647, default: 2]
        I:nestedInt=2

        # 
        # Possible values: [VALUE1, VALUE2, VALUE3, VALUE4]
        #  [default: VALUE2]
        S:testEnum2=VALUE2

        ##########################################################################################################
        # subsubconfig
        #--------------------------------------------------------------------------------------------------------#
        # This is a test comment
        ##########################################################################################################

        subsubconfig {
            #  [range: -2147483648 ~ 2147483647, default: 3]
            I:nestedNestedInt=3
        }

    }

}
```
