### PR TITLE
EventBusSubscriber improvements

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
@@ -6,9 +6,11 @@ import net.minecraftforge.common.util.FakePlayer;
 
 import com.gtnewhorizon.gtnhlib.config.ConfigurationManager;
 import com.gtnewhorizon.gtnhlib.eventbus.AutoEventBus;
+import com.gtnewhorizon.gtnhlib.eventbus.Phase;
 import com.gtnewhorizon.gtnhlib.network.NetworkHandler;
 import com.gtnewhorizon.gtnhlib.network.PacketMessageAboveHotbar;
 
+import cpw.mods.fml.common.event.FMLConstructionEvent;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
@@ -20,13 +22,17 @@ import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 
 public class CommonProxy {
 
+    public void construct(FMLConstructionEvent event) {
+        AutoEventBus.executePhase(Phase.CONSTRUCT);
+    }
+
     public void preInit(FMLPreInitializationEvent event) {
-        AutoEventBus.init(event.getAsmData());
+        AutoEventBus.executePhase(Phase.PRE);
         GTNHLib.info("GTNHLib version " + Tags.VERSION + " loaded.");
     }
 
     public void init(FMLInitializationEvent event) {
-        AutoEventBus.registerSubscribers();
+        AutoEventBus.executePhase(Phase.INIT);
         NetworkHandler.init();
         ConfigurationManager.onInit();
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLib.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLib.java
@@ -24,6 +24,11 @@ public class GTNHLib {
     public static CommonProxy proxy;
 
     @Mod.EventHandler
+    public void construct(FMLConstructionEvent event) {
+        proxy.construct(event);
+    }
+
+    @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
         proxy.preInit(event);
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.service.mojang.MixinServiceLaunchWrapper;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.gtnewhorizon.gtnhlib.Tags;
-import com.gtnewhorizon.gtnhlib.core.transformer.EventBusSubTransformer;
+import com.gtnewhorizon.gtnhlib.eventbus.EventBusUtil;
 import com.gtnewhorizon.gtnhlib.mixins.Mixins;
 import com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader;
 
@@ -93,6 +93,6 @@ public class GTNHLibCore extends DummyModContainer implements IFMLLoadingPlugin,
 
     @Subscribe
     public void construct(FMLConstructionEvent event) {
-        EventBusSubTransformer.harvestData(event.getASMHarvestedData());
+        EventBusUtil.harvestData(event.getASMHarvestedData());
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/core/transformer/EventBusSubTransformer.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/core/transformer/EventBusSubTransformer.java
@@ -21,7 +21,6 @@ import com.gtnewhorizon.gtnhlib.eventbus.EventBusUtil;
 import com.gtnewhorizon.gtnhlib.eventbus.MethodInfo;
 
 import cpw.mods.fml.common.Optional;
-import cpw.mods.fml.common.discovery.ASMDataTable;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.relauncher.FMLLaunchHandler;
@@ -42,21 +41,14 @@ public class EventBusSubTransformer implements IClassTransformer {
     private static final List<String> ANNOTATIONS = Arrays
             .asList(OPTIONAL_DESC, SIDEONLY_DESC, SUBSCRIBE_DESC, CONDITION_DESC);
     private static final String CURRENT_SIDE = FMLLaunchHandler.side().name();
-    private static ObjectSet<String> classesToVisit;
-
-    public static void harvestData(ASMDataTable table) {
-        classesToVisit = EventBusUtil.getClassesToVisit();
-        for (ASMDataTable.ASMData data : table.getAll(EventBusSubscriber.class.getName())) {
-            classesToVisit.add(data.getClassName());
-        }
-    }
+    private static final ObjectSet<String> classesToVisit = EventBusUtil.getClassesToVisit();
 
     @Override
     public byte[] transform(String name, String transformedName, byte[] basicClass) {
         if (basicClass == null) return null;
 
         // It's either too early or this class isn't an @EventBusSubscriber
-        if (classesToVisit == null || !classesToVisit.contains(transformedName)) {
+        if (classesToVisit.isEmpty() || !classesToVisit.contains(transformedName)) {
             return basicClass;
         }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/AutoEventBus.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/AutoEventBus.java
@@ -2,13 +2,15 @@ package com.gtnewhorizon.gtnhlib.eventbus;
 
 import static com.gtnewhorizon.gtnhlib.eventbus.EventBusUtil.DEBUG_EVENT_BUS;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.lang.invoke.CallSite;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
@@ -17,30 +19,24 @@ import javax.annotation.Nullable;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.terraingen.OreGenEvent;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
-import com.gtnewhorizon.gtnhlib.mixins.early.fml.EnumHolderAccessor;
 import com.gtnewhorizon.gtnhlib.mixins.early.fml.EventBusAccessor;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModContainer;
-import cpw.mods.fml.common.discovery.ASMDataTable;
 import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.common.eventhandler.EventBus;
 import cpw.mods.fml.common.eventhandler.IEventListener;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectList;
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -50,12 +46,10 @@ public class AutoEventBus {
 
     private static final Logger LOGGER = LogManager.getLogger("GTNHLib EventBus");
     private static final DummyEvent INVALID_EVENT = new DummyEvent();
-    private static final Object2ObjectMap<ModContainer, ObjectSet<String>> subscribers = new Object2ObjectOpenHashMap<>();
-    private static final Object2ObjectMap<String, ModContainer> classPathToModLookup = new Object2ObjectOpenHashMap<>();
     private static final Object2ObjectMap<String, Event> eventCache = new Object2ObjectOpenHashMap<>();
     private static final Object2BooleanMap<String> optionalMods = new Object2BooleanOpenHashMap<>();
-
-    private static boolean hasRegistered;
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+    private static final MethodType CONDITION_TYPE = MethodType.methodType(boolean.class);
 
     private enum EventBusType {
 
@@ -83,58 +77,16 @@ public class AutoEventBus {
         }
     }
 
-    public static void init(ASMDataTable dataTable) {
-        for (ModContainer container : Loader.instance().getActiveModList()) {
-            Object modObject = container.getMod();
-            if (modObject == null) continue;
-            Package modPackage = modObject.getClass().getPackage();
-            if (modPackage == null) continue;
-            classPathToModLookup.put(modPackage.getName(), container);
-        }
+    public static void executePhase(Phase phase) {
+        if (phase.hasExecuted) return;
+        phase.hasExecuted = true;
+        Object2ObjectMap<ModContainer, ObjectSet<String>> subscribers = phase.getModClassesForPhase();
+        if (subscribers.isEmpty()) return;
 
-        for (String className : EventBusUtil.getClassesToVisit()) {
-            ModContainer mod = getOwningModContainer(className);
-            subscribers.computeIfAbsent(mod, k -> new ObjectOpenHashSet<>()).add(className);
-        }
-
-        // Due to the way we are registering events, we need to filter invalid sides out manually.
-        // It's much faster to do it here than to load an invalid class and throw a couple exceptions.
-        Side currentSide = FMLCommonHandler.instance().getSide();
-        for (Object2ObjectMap.Entry<ModContainer, ObjectSet<String>> entry : subscribers.object2ObjectEntrySet()) {
-            Set<ASMDataTable.ASMData> sideOnly = dataTable.getAnnotationsFor(entry.getKey())
-                    .get(SideOnly.class.getName());
-
-            for (ASMDataTable.ASMData data : sideOnly) {
-                if (!data.getObjectName().equals(data.getClassName())) {
-                    continue;
-                }
-
-                Map<String, Object> sideInfo = data.getAnnotationInfo();
-                Side side = Side.valueOf(((EnumHolderAccessor) sideInfo.get("value")).getValue());
-                if (side != currentSide) {
-                    entry.getValue().remove(data.getClassName());
-                }
-            }
-        }
-    }
-
-    public static void registerSubscribers() {
-        if (hasRegistered) return;
-        hasRegistered = true;
         for (Object2ObjectMap.Entry<ModContainer, ObjectSet<String>> entry : subscribers.object2ObjectEntrySet()) {
             for (String className : entry.getValue()) {
                 try {
                     Class<?> clazz = Class.forName(className, false, Loader.instance().getModClassLoader());
-                    if (!isValidSide(clazz)) {
-                        if (DEBUG_EVENT_BUS) {
-                            LOGGER.info(
-                                    "Skipping registration for {}, invalid side {}",
-                                    clazz.getSimpleName(),
-                                    FMLCommonHandler.instance().getSide());
-                        }
-                        continue;
-                    }
-
                     String conditionToCheck = EventBusUtil.getConditionsToCheck().get(className);
                     if (conditionToCheck != null && !isConditionMet(clazz, conditionToCheck)) {
                         if (DEBUG_EVENT_BUS) {
@@ -146,22 +98,23 @@ public class AutoEventBus {
                     ObjectSet<MethodInfo> methods = EventBusUtil.getMethodsToSubscribe().get(className);
                     if (methods == null || methods.isEmpty()) continue;
                     register(entry.getKey(), clazz, methods);
-                } catch (IllegalAccessException | ClassNotFoundException e) {
+                } catch (ClassNotFoundException e) {
                     if (DEBUG_EVENT_BUS) LOGGER.error("Failed to load class {}", className, e);
                 }
             }
         }
 
-        ObjectList<String> invalidMethods = EventBusUtil.getInvalidMethods();
-        if (invalidMethods.size() == 1) {
-            throw new IllegalArgumentException(invalidMethods.get(0));
-        } else if (invalidMethods.size() > 1) {
-            int i;
-            for (i = 0; i < invalidMethods.size() - 1; i++) {
-                LOGGER.error(invalidMethods.get(i));
+        if (phase == Phase.INIT) {
+            ObjectList<String> invalidMethods = EventBusUtil.getInvalidMethods();
+            if (invalidMethods.size() == 1) {
+                throw new IllegalArgumentException(invalidMethods.get(0));
+            } else if (invalidMethods.size() > 1) {
+                int i;
+                for (i = 0; i < invalidMethods.size() - 1; i++) {
+                    LOGGER.error(invalidMethods.get(i));
+                }
+                throw new IllegalArgumentException("Encountered" + i + "invalid methods. " + invalidMethods.get(i));
             }
-            throw new IllegalArgumentException(
-                    "Encountered" + invalidMethods.size() + "invalid methods. " + invalidMethods.get(i));
         }
     }
 
@@ -177,7 +130,7 @@ public class AutoEventBus {
                 Event event = getCachedEvent(EventBusUtil.getParameterClassName(method.desc));
                 if (INVALID_EVENT.equals(event)) continue;
 
-                StaticASMEventHandler listener = new StaticASMEventHandler(classOwner, method);
+                StaticASMEventHandler listener = new StaticASMEventHandler(method);
                 for (EventBusType bus : EventBusType.VALUES) {
                     if (!bus.canRegister(event.getClass())) {
                         continue;
@@ -213,37 +166,20 @@ public class AutoEventBus {
     private static boolean isConditionMet(@NotNull Class<?> clazz, @Nullable String condition) {
         if (condition == null) return true;
         try {
-            if (condition.contains("()Z")) {
-                Method method = clazz.getDeclaredMethod(condition.substring(0, condition.indexOf("(")));
-                method.setAccessible(true);
-                return (boolean) method.invoke(null);
-            }
-
-            Field field = clazz.getDeclaredField(condition);
-            field.setAccessible(true);
-            return field.getBoolean(null);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | NoSuchFieldException e) {
-            if (DEBUG_EVENT_BUS) LOGGER.error("Failed to invoke condition {} for class {}", condition, clazz, e);
+            MethodHandle handle = MethodHandles.publicLookup()
+                    .findStatic(clazz, condition.substring(0, condition.indexOf("(")), CONDITION_TYPE);
+            CallSite call = LambdaMetafactory.metafactory(
+                    LOOKUP,
+                    "getAsBoolean",
+                    MethodType.methodType(BooleanSupplier.class),
+                    CONDITION_TYPE,
+                    handle,
+                    CONDITION_TYPE);
+            return ((BooleanSupplier) call.getTarget().invokeWithArguments()).getAsBoolean();
+        } catch (Throwable e) {
+            LOGGER.error("Failed to invoke condition {} for class {}", condition, clazz, e);
             return false;
         }
-    }
-
-    private static @Nonnull ModContainer getOwningModContainer(String className) {
-        return classPathToModLookup.object2ObjectEntrySet().stream().filter(e -> className.startsWith(e.getKey()))
-                .map(Map.Entry::getValue).findFirst().orElse(Loader.instance().getMinecraftModContainer());
-    }
-
-    private static boolean isValidSide(Class<?> subscribedClass) throws IllegalAccessException {
-        Side currentSide = FMLCommonHandler.instance().getSide();
-        if (currentSide.isClient()) return true;
-
-        EventBusSubscriber subscriber = subscribedClass.getAnnotation(EventBusSubscriber.class);
-        Side[] sides = subscriber.side();
-        if (sides.length == 1) {
-            return currentSide == sides[0];
-        }
-
-        return !StringUtils.containsIgnoreCase(subscribedClass.getName(), "client");
     }
 
     private static boolean isFMLEvent(Class<?> event) {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusSubscriber.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusSubscriber.java
@@ -9,7 +9,8 @@ import cpw.mods.fml.relauncher.Side;
 
 /**
  * Annotation to mark a class as an EventBus subscriber. Classes annotated with this will automatically be registered to
- * listen for events. Registration will happen during the init phase.<br>
+ * listen for events. Registration will happen during the specified {@link EventBusSubscriber#phase()} or during
+ * {@link Phase#INIT} if not specified. <br>
  * All methods annotated with {@link cpw.mods.fml.common.eventhandler.SubscribeEvent} are expected to be static.
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -22,13 +23,15 @@ public @interface EventBusSubscriber {
      */
     Side[] side() default { Side.CLIENT, Side.SERVER };
 
+    /**
+     * Which equivalent {@link cpw.mods.fml.common.LoaderState} this subscriber should be registered during.
+     */
     Phase phase() default Phase.INIT;
 
     /**
      * Can be applied to a boolean method in the annotated class that provides a condition for registering the
      * subscriber. It is expected that the method is static, returns a boolean, and takes no parameters. <br>
-     * There is expected to be at most one condition for a class. Config values can be used as the return value since
-     * registration happens during init.
+     * There is expected to be at most one condition for a class.
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusSubscriber.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusSubscriber.java
@@ -22,14 +22,16 @@ public @interface EventBusSubscriber {
      */
     Side[] side() default { Side.CLIENT, Side.SERVER };
 
+    Phase phase() default Phase.INIT;
+
     /**
-     * Can be applied to a boolean field/method in the annotated class that provides a condition for registering the
-     * subscriber. It is expected that the field/method is static, returns a boolean, and takes no parameters. <br>
+     * Can be applied to a boolean method in the annotated class that provides a condition for registering the
+     * subscriber. It is expected that the method is static, returns a boolean, and takes no parameters. <br>
      * There is expected to be at most one condition for a class. Config values can be used as the return value since
      * registration happens during init.
      */
     @Retention(RetentionPolicy.RUNTIME)
-    @Target({ ElementType.FIELD, ElementType.METHOD })
+    @Target(ElementType.METHOD)
     @interface Condition {}
 
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusUtil.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusUtil.java
@@ -1,7 +1,5 @@
 package com.gtnewhorizon.gtnhlib.eventbus;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -11,7 +9,6 @@ import com.gtnewhorizon.gtnhlib.mixins.early.fml.EnumHolderAccessor;
 
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.discovery.ASMDataTable;
-import cpw.mods.fml.common.discovery.ModCandidate;
 import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import cpw.mods.fml.relauncher.SideOnly;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
@@ -49,13 +46,7 @@ public final class EventBusUtil {
     }
 
     public static void harvestData(ASMDataTable table) {
-        List<ASMDataTable.ASMData> asmData = new ArrayList<>(table.getAll(EventBusSubscriber.class.getName()));
-        asmData.sort(((o1, o2) -> {
-            ModCandidate mod1 = o1.getCandidate();
-            ModCandidate mod2 = o2.getCandidate();
-            return mod1.getModContainer().getName().compareTo(mod2.getModContainer().getName());
-        }));
-
+        Set<ASMDataTable.ASMData> asmData = table.getAll(EventBusSubscriber.class.getName());
         ObjectSet<String> excludedClasses = getExcludedClasses(table);;
         for (ASMDataTable.ASMData data : asmData) {
             Map<String, Object> info = data.getAnnotationInfo();

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusUtil.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusUtil.java
@@ -1,5 +1,19 @@
 package com.gtnewhorizon.gtnhlib.eventbus;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.gtnewhorizon.gtnhlib.mixins.early.fml.EnumHolderAccessor;
+
+import cpw.mods.fml.common.ModContainer;
+import cpw.mods.fml.common.discovery.ASMDataTable;
+import cpw.mods.fml.common.discovery.ModCandidate;
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
+import cpw.mods.fml.relauncher.SideOnly;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
@@ -11,6 +25,7 @@ import lombok.Getter;
 public final class EventBusUtil {
 
     public static final Boolean DEBUG_EVENT_BUS = Boolean.getBoolean("gtnhlib.debug.eventbus");
+    private static final String CURRENT_SIDE = FMLLaunchHandler.side().name();
 
     @Getter
     private static final ObjectSet<String> classesToVisit = new ObjectOpenHashSet<>();
@@ -31,5 +46,66 @@ public final class EventBusUtil {
 
     static String getSimpleClassName(String desc) {
         return desc.substring(desc.lastIndexOf(".") + 1);
+    }
+
+    public static void harvestData(ASMDataTable table) {
+        List<ASMDataTable.ASMData> asmData = new ArrayList<>(table.getAll(EventBusSubscriber.class.getName()));
+        asmData.sort(((o1, o2) -> {
+            ModCandidate mod1 = o1.getCandidate();
+            ModCandidate mod2 = o2.getCandidate();
+            return mod1.getModContainer().getName().compareTo(mod2.getModContainer().getName());
+        }));
+
+        ObjectSet<String> excludedClasses = getExcludedClasses(table);;
+        for (ASMDataTable.ASMData data : asmData) {
+            Map<String, Object> info = data.getAnnotationInfo();
+            String className = data.getClassName();
+            Phase phase = Phase.INIT;
+            if (info != null) {
+                if (info.containsKey("phase")) {
+                    phase = Phase.valueOf(((EnumHolderAccessor) info.get("phase")).getValue());
+                }
+                // FML can't handle annotation enum arrays so this key is always null and only holds one value.
+                if (info.containsKey(null)) {
+                    String side = ((EnumHolderAccessor) info.get(null)).getValue();
+                    if (!isValidSide(side, className)) continue;
+                }
+            }
+
+            ModContainer mod = data.getCandidate().getContainedMods().get(0);
+            if (excludedClasses.contains(className)) continue;
+
+            phase.getModClassesForPhase().computeIfAbsent(mod, k -> new ObjectOpenHashSet<>()).add(className);
+            classesToVisit.add(className);
+        }
+    }
+
+    private static ObjectSet<String> getExcludedClasses(ASMDataTable dataTable) {
+        // Due to the way we are registering events, we need to filter invalid sides out manually.
+        // It's much faster to do it here than to load an invalid class and throw a couple exceptions.
+        // For some reason it is MUCH faster to do getAll rather than getAnnotationsFor
+        Set<ASMDataTable.ASMData> dat = dataTable.getAll(SideOnly.class.getName());
+        ObjectSet<String> excludedClasses = new ObjectOpenHashSet<>();
+        for (ASMDataTable.ASMData data : dat) {
+            String className = data.getClassName();
+            if (!data.getObjectName().equals(className)) {
+                continue;
+            }
+
+            Map<String, Object> sideInfo = data.getAnnotationInfo();
+            String side = ((EnumHolderAccessor) sideInfo.get("value")).getValue();
+            if (!CURRENT_SIDE.equals(side)) {
+                excludedClasses.add(className);
+            }
+        }
+        return excludedClasses;
+    }
+
+    private static boolean isValidSide(String side, String className) {
+        if (CURRENT_SIDE.equals("CLIENT")) {
+            return side.equals(CURRENT_SIDE);
+        }
+
+        return !StringUtils.containsIgnoreCase(className, "client") && !side.equals("CLIENT");
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/Phase.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/Phase.java
@@ -4,17 +4,29 @@ import cpw.mods.fml.common.ModContainer;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
+import lombok.AccessLevel;
 import lombok.Getter;
 
 public enum Phase {
 
+    /**
+     * Registered during {@link cpw.mods.fml.common.event.FMLConstructionEvent}.
+     */
     CONSTRUCT,
+
+    /**
+     * Registered during {@link cpw.mods.fml.common.event.FMLPreInitializationEvent}.
+     */
     PRE,
+
+    /**
+     * Registered during {@link cpw.mods.fml.common.event.FMLInitializationEvent}.
+     */
     INIT;
 
     boolean hasExecuted = false;
 
-    @Getter
+    @Getter(AccessLevel.PACKAGE)
     private final Object2ObjectMap<ModContainer, ObjectSet<String>> modClassesForPhase = new Object2ObjectOpenHashMap<>();
 
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/Phase.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/Phase.java
@@ -1,0 +1,20 @@
+package com.gtnewhorizon.gtnhlib.eventbus;
+
+import cpw.mods.fml.common.ModContainer;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+import lombok.Getter;
+
+public enum Phase {
+
+    CONSTRUCT,
+    PRE,
+    INIT;
+
+    boolean hasExecuted = false;
+
+    @Getter
+    private final Object2ObjectMap<ModContainer, ObjectSet<String>> modClassesForPhase = new Object2ObjectOpenHashMap<>();
+
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/StaticASMEventHandler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/StaticASMEventHandler.java
@@ -2,17 +2,13 @@ package com.gtnewhorizon.gtnhlib.eventbus;
 
 import static org.objectweb.asm.Opcodes.*;
 
-import org.apache.logging.log4j.ThreadContext;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 
-import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.IEventListener;
-import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import lombok.Getter;
 
 public class StaticASMEventHandler implements IEventListener {
@@ -22,18 +18,14 @@ public class StaticASMEventHandler implements IEventListener {
     private static final String HANDLER_FUNC_DESC = Type
             .getMethodDescriptor(IEventListener.class.getDeclaredMethods()[0]);
     private static final ASMClassLoader LOADER = new ASMClassLoader();
-    private static final Object2ObjectMap<String, Class<?>> cache = new Object2ObjectOpenHashMap<>();
-    private static final boolean GETCONTEXT = Boolean.parseBoolean(System.getProperty("fml.LogContext", "false"));
 
     private final IEventListener handler;
-    private final ModContainer owner;
     private final String readable;
     private final boolean receiveCanceled;
     @Getter
     private final EventPriority priority;
 
-    StaticASMEventHandler(ModContainer owner, MethodInfo method) throws Exception {
-        this.owner = owner;
+    StaticASMEventHandler(MethodInfo method) throws Exception {
         handler = (IEventListener) createWrapper(method).getDeclaredConstructor().newInstance();
         readable = "ASM: " + method.getDeclaringClass() + " " + method.getName() + method.getDesc();
         receiveCanceled = method.receiveCanceled;
@@ -42,23 +34,13 @@ public class StaticASMEventHandler implements IEventListener {
 
     @Override
     public void invoke(Event event) {
-        if (owner != null && GETCONTEXT) {
-            ThreadContext.put("mod", owner.getName());
-        } else if (GETCONTEXT) {
-            ThreadContext.put("mod", "");
+        if (handler == null) return;
+        if (!event.isCancelable() || !event.isCanceled() || receiveCanceled) {
+            handler.invoke(event);
         }
-        if (handler != null) {
-            if (!event.isCancelable() || !event.isCanceled() || receiveCanceled) {
-                handler.invoke(event);
-            }
-        }
-        if (GETCONTEXT) ThreadContext.remove("mod");
     }
 
     public Class<?> createWrapper(MethodInfo method) {
-        Class<?> cached = cache.get(method.getKey());
-        if (cached != null) return cached;
-
         ClassWriter cw = new ClassWriter(0);
         MethodVisitor mv;
 
@@ -91,9 +73,7 @@ public class StaticASMEventHandler implements IEventListener {
             mv.visitEnd();
         }
         cw.visitEnd();
-        Class<?> ret = LOADER.define(name, cw.toByteArray());
-        cache.put(method.getKey(), ret);
-        return ret;
+        return LOADER.define(name, cw.toByteArray());
     }
 
     private String getUniqueName(MethodInfo method) {


### PR DESCRIPTION
Invoking the `@EventBusSubscriber.Condition` method suffered from the same reflection problems as described in https://github.com/GTNewHorizons/GTNHLib/pull/80, which is that it will have to load the entire method table including parameters classes that might not be present. 

Having to dynamically invoke a given method without reflection only leaves a few options, which are either using `MethodHandle` which are generally faster than reflection if invoked a ton of times but significantly slower if only invoked once 
or using the semi-obscure `LambdaMetafactory` api. This generates a synthetic anonymous class that implements a functional interface to get a value from the specified method, while that might sound like it would be a lot slower than reflection it was in fact consistently faster and doesn't have to load the entire method table.


Makes `@EventBusSubscriber`'s able to be registered during earlier init phases as some events are  fired during pre-init, specifically some of the registry events. This means that if an `@EventBusSubscriber` wants to listen to that event and potentially pick up something that gets fired during the pre-init phase of a mod that loads earlier than NHLib, it would have to be registered during the construction phase. This is only applicable in very few cases but I thought it'd be best to at least make it an option.

Also some different minor improvements like using `ASMDataTable.getAll` to get the side-only classes instead of `ASMDataTable.getAnnotationsFor`. This alone lowered the time it took for that part of the pre-proccesing from ~90ms to ~5-15ms on my GT5U test branch, and that was while only ever using `ASMDataTable.getAnnotationsFor` twice...