### PR TITLE
Add texture debug feature

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
@@ -82,7 +82,12 @@ public class GTNHLibCore extends DummyModContainer implements IFMLLoadingPlugin,
 
     @Override
     public List<String> getMixins(Set<String> loadedCoreMods) {
-        return Mixins.getEarlyMixins(loadedCoreMods);
+        final List<String> mixins = Mixins.getEarlyMixins(loadedCoreMods);
+        if (Boolean.parseBoolean(System.getProperty("gtnhlib.debugtextures", "false"))) {
+            mixins.add("debug.MixinDynamicTexture");
+            mixins.add("debug.MixinTextureAtlasSprite");
+        }
+        return mixins;
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
@@ -82,12 +82,7 @@ public class GTNHLibCore extends DummyModContainer implements IFMLLoadingPlugin,
 
     @Override
     public List<String> getMixins(Set<String> loadedCoreMods) {
-        final List<String> mixins = Mixins.getEarlyMixins(loadedCoreMods);
-        if (Boolean.parseBoolean(System.getProperty("gtnhlib.debugtextures", "false"))) {
-            mixins.add("debug.MixinDynamicTexture");
-            mixins.add("debug.MixinTextureAtlasSprite");
-        }
-        return mixins;
+        return Mixins.getEarlyMixins(loadedCoreMods);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/gtnhlib/debug/TexturesDebug.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/debug/TexturesDebug.java
@@ -1,0 +1,74 @@
+package com.gtnewhorizon.gtnhlib.debug;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import net.minecraft.client.Minecraft;
+
+public class TexturesDebug {
+
+    private static boolean initSpriteLogger = false;
+    private static PrintStream logAtlasSprite = null;
+    private static boolean initDynamicLogger = false;
+    private static PrintStream logDynamic = null;
+
+    public static void logTextureAtlasSprite(String iconName, int width, int height, int frames, int sizeBytes) {
+        logTextureAtlasSprite(iconName + "," + width + "," + height + "," + frames + "," + sizeBytes);
+    }
+
+    private static void logTextureAtlasSprite(String message) {
+        if (!initSpriteLogger) {
+            logAtlasSprite = initLogger("TexturesDebug.csv");
+            initSpriteLogger = true;
+            logTextureAtlasSprite("iconName,width,height,frames,sizeBytes");
+        }
+        if (logAtlasSprite != null) {
+            logAtlasSprite.println(message);
+        }
+    }
+
+    public static void logDynamicTexture(int width, int height) {
+        if (!initDynamicLogger) {
+            logDynamic = initLogger("DynamicTextures.txt");
+            initDynamicLogger = true;
+        }
+        if (logDynamic != null) {
+            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            logDynamic.println("Created texture of width " + width + " height " + height);
+            for (int i = 0; i < stackTrace.length; i++) {
+                StackTraceElement element = stackTrace[i];
+                if (i == 4 || i == 5) {
+                    logDynamic.println("at " + element);
+                    break;
+                }
+            }
+            logDynamic.println(" ");
+        }
+    }
+
+    private static PrintStream initLogger(String file) {
+        final File logFile = new File(Minecraft.getMinecraft().mcDataDir, file);
+        if (logFile.exists()) {
+            // noinspection ResultOfMethodCallIgnored
+            logFile.delete();
+        }
+        if (!logFile.exists()) {
+            try {
+                // noinspection ResultOfMethodCallIgnored
+                logFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        try {
+            return new PrintStream(new FileOutputStream(logFile, true));
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -18,12 +18,14 @@ public enum Mixins {
             .setApplyIf(() -> true).addMixinClasses("MixinTessellator")),
     WAVEFRONT_VBO(new Builder("WavefrontObject").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)
             .setPhase(Phase.EARLY).setApplyIf(() -> true).addMixinClasses("MixinWavefrontObject")),
-
     GUI_MOD_LIST(new Builder("Auto config ui").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)
             .setPhase(Phase.EARLY).addMixinClasses("fml.MixinGuiModList")),
-
     EVENT_BUS_ACCESSOR(new Builder("EventBusAccessor").addTargetedMod(TargetedMod.VANILLA).setSide(Side.BOTH)
-            .setPhase(Phase.EARLY).addMixinClasses("fml.EventBusAccessor", "fml.EnumHolderAccessor"));
+            .setPhase(Phase.EARLY).addMixinClasses("fml.EventBusAccessor", "fml.EnumHolderAccessor")),
+    DEBUG_TEXTURES(new Builder("Dump textures sizes").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)
+            .setPhase(Phase.EARLY)
+            .setApplyIf(() -> Boolean.parseBoolean(System.getProperty("gtnhlib.debugtextures", "false")))
+            .addMixinClasses("debug.MixinDynamicTexture", "debug.MixinTextureAtlasSprite"));
 
     private final List<String> mixinClasses;
     private final Supplier<Boolean> applyIf;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/debug/MixinDynamicTexture.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/debug/MixinDynamicTexture.java
@@ -1,0 +1,22 @@
+package com.gtnewhorizon.gtnhlib.mixins.early.debug;
+
+import net.minecraft.client.renderer.texture.DynamicTexture;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizon.gtnhlib.debug.TexturesDebug;
+
+@Mixin(DynamicTexture.class)
+public class MixinDynamicTexture {
+
+    @Inject(method = "<init>(II)V", at = @At("RETURN"))
+    private void gtnhlib$debug(int width, int height, CallbackInfo ci) {
+        if (width > 16 || height > 16) {
+            TexturesDebug.logDynamicTexture(width, height);
+        }
+    }
+
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/debug/MixinTextureAtlasSprite.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/debug/MixinTextureAtlasSprite.java
@@ -1,0 +1,48 @@
+package com.gtnewhorizon.gtnhlib.mixins.early.debug;
+
+import java.awt.image.BufferedImage;
+import java.util.List;
+
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.data.AnimationMetadataSection;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizon.gtnhlib.debug.TexturesDebug;
+
+@Mixin(TextureAtlasSprite.class)
+public class MixinTextureAtlasSprite {
+
+    @Shadow
+    protected List<int[][]> framesTextureData;
+
+    @Shadow
+    @Final
+    private String iconName;
+
+    @Shadow
+    protected int width;
+
+    @Shadow
+    protected int height;
+
+    @Inject(method = "loadSprite", at = @At("RETURN"))
+    private void gtnhlib$debug(BufferedImage[] buff, AnimationMetadataSection anim, boolean p_147964_3_,
+            CallbackInfo ci) {
+        int sizeBytes = 0;
+        for (int[][] ints : framesTextureData) {
+            for (int[] pixels : ints) {
+                if (pixels != null) {
+                    sizeBytes += pixels.length * 4;
+                }
+            }
+        }
+        TexturesDebug.logTextureAtlasSprite(iconName, width, height, framesTextureData.size(), sizeBytes);
+    }
+
+}


### PR DESCRIPTION
Using `-Dgtnhlib.debugtextures=true` will now create two files in your `.minecraft` folder that will list all the registered textures in a `csv` file with their name, width, height, amount of frames and the size in bytes it takes in the RAM.

We should use this to point to all the textures that are too large and rework them.