### PR TITLE
Shadow source jars too

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,5 +13,5 @@ tasks.processResources {
 // Shadow source jars too
 val shadowSources = configurations.getByName("shadowSources")
 tasks.sourcesJar {
-    from(shadowSources.map { zipTree(it) }) // idr what the operator here is, something that applies zipTree to all elements
+    from(shadowSources.map { zipTree(it) })
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,3 +9,9 @@ tasks.processResources {
         expand("version" to project.version.toString())
     }
 }
+
+// Shadow source jars too
+val shadowSources = configurations.getByName("shadowSources")
+tasks.sourcesJar {
+    from(shadowSources.map { zipTree(it) }) // idr what the operator here is, something that applies zipTree to all elements
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,8 +1,13 @@
 // Add your dependencies here
+configurations {
+    shadowSources
+}
 
 dependencies {
     shadowImplementation("it.unimi.dsi:fastutil:8.5.12") // Apache 2.0
     shadowImplementation("org.joml:joml:1.10.5") // MIT
+    shadowSources("it.unimi.dsi:fastutil:8.5.12:sources")
+    shadowSources("org.joml:joml:1.10.5:sources")
 
     testImplementation(platform("org.junit:junit-bom:5.9.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")


### PR DESCRIPTION
The `shadow` plugin doesn't support shading source jars by default, so this adds a way to manually do it. Fastutil and JOML sources will be available in dev envs now, at the cost of a larger sources jar.