### PR TITLE
Disable thread safety checks with FalseTweaks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -22,4 +22,7 @@ dependencies {
     compileOnly('org.jetbrains:annotations:24.0.1')
     compileOnly("org.projectlombok:lombok:1.18.22") {transitive = false }
     annotationProcessor("org.projectlombok:lombok:1.18.22")
+
+    // For CapturingTesselator compat
+    compileOnly("com.falsepattern:falsetweaks-mc1.7.10:3.3.2:api")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -75,7 +75,7 @@ replaceGradleTokenInFile =
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
 # Example value: (apiPackage = api) + (modGroup = com.myname.mymodid) -> com.myname.mymodid.api
-apiPackage =
+apiPackage = api
 
 # Specify the configuration file for Forge's access transformers here. It must be placed into /src/main/resources/META-INF/
 # There can be multiple files in a space-separated list.

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,5 +1,7 @@
 // Add any additional repositories for your dependencies here
 
 repositories {
-
+    maven {
+        url = uri("https://mvn.falsepattern.com/releases")
+    }
 }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -2,6 +2,10 @@
 
 repositories {
     maven {
-        url = uri("https://mvn.falsepattern.com/releases")
+        name = 'mavenpattern'
+        url = 'https://mvn.falsepattern.com/releases'
+        content {
+            includeGroup 'com.falsepattern'
+        }
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
@@ -2,8 +2,6 @@ package com.gtnewhorizon.gtnhlib;
 
 import static com.gtnewhorizon.gtnhlib.client.model.ModelLoader.shouldLoadModels;
 
-import com.gtnewhorizon.gtnhlib.compat.FalseTweaks;
-import com.gtnewhorizon.gtnhlib.compat.Mods;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
@@ -12,6 +10,8 @@ import net.minecraftforge.client.ClientCommandHandler;
 
 import com.gtnewhorizon.gtnhlib.client.model.ModelLoader;
 import com.gtnewhorizon.gtnhlib.commands.ItemInHandCommand;
+import com.gtnewhorizon.gtnhlib.compat.FalseTweaks;
+import com.gtnewhorizon.gtnhlib.compat.Mods;
 import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
 import com.gtnewhorizon.gtnhlib.util.AboveHotbarHUD;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
@@ -2,6 +2,8 @@ package com.gtnewhorizon.gtnhlib;
 
 import static com.gtnewhorizon.gtnhlib.client.model.ModelLoader.shouldLoadModels;
 
+import com.gtnewhorizon.gtnhlib.compat.FalseTweaks;
+import com.gtnewhorizon.gtnhlib.compat.Mods;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
@@ -23,7 +25,7 @@ import cpw.mods.fml.relauncher.Side;
 public class ClientProxy extends CommonProxy {
 
     private static boolean modelsBaked = false;
-
+    public static boolean doThreadSafetyChecks = true;
     private final Minecraft mc = Minecraft.getMinecraft();
 
     @Override
@@ -40,6 +42,13 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void postInit(FMLPostInitializationEvent event) {
         super.postInit(event);
+
+        if (Mods.FALSETWEAKS) {
+            doThreadSafetyChecks = FalseTweaks.doTessSafetyChecks();
+            if (!doThreadSafetyChecks) {
+                GTNHLib.info("FalseTweaks threaded rendering is enabled - disabling GTNHLib's thread safety checks");
+            }
+        }
 
         if (shouldLoadModels()) {
             Minecraft.getMinecraft().refreshResources();

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/CapturingTesselator.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/CapturingTesselator.java
@@ -1,0 +1,10 @@
+package com.gtnewhorizon.gtnhlib.api;
+
+import com.gtnewhorizon.gtnhlib.client.renderer.TessellatorManager;
+
+public class CapturingTesselator {
+
+    public static boolean isCapturing() {
+        return TessellatorManager.isCurrentlyCapturing();
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/CapturingTesselator.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/CapturingTesselator.java
@@ -1,10 +1,23 @@
 package com.gtnewhorizon.gtnhlib.api;
 
 import com.gtnewhorizon.gtnhlib.client.renderer.TessellatorManager;
+import net.minecraft.client.renderer.Tessellator;
 
-public class CapturingTesselator {
-
-    public static boolean isCapturing() {
+@SuppressWarnings("unused")
+public interface CapturingTesselator {
+    /**
+     * @return True if this thread is capturing quads, false otherwise
+     */
+    static boolean isCapturing() {
         return TessellatorManager.isCurrentlyCapturing();
+    }
+
+    /**
+     * @throws IllegalStateException If the thread is not capturing and is not the main one.
+     * @return The CapturingTesselator for this thread if capturing, or else {@link Tessellator#instance} if on the main
+     * one.
+     */
+    static Tessellator getThreadTesselator() {
+        return TessellatorManager.get();
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/CapturingTesselator.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/CapturingTesselator.java
@@ -1,10 +1,12 @@
 package com.gtnewhorizon.gtnhlib.api;
 
-import com.gtnewhorizon.gtnhlib.client.renderer.TessellatorManager;
 import net.minecraft.client.renderer.Tessellator;
+
+import com.gtnewhorizon.gtnhlib.client.renderer.TessellatorManager;
 
 @SuppressWarnings("unused")
 public interface CapturingTesselator {
+
     /**
      * @return True if this thread is capturing quads, false otherwise
      */
@@ -15,7 +17,7 @@ public interface CapturingTesselator {
     /**
      * @throws IllegalStateException If the thread is not capturing and is not the main one.
      * @return The CapturingTesselator for this thread if capturing, or else {@link Tessellator#instance} if on the main
-     * one.
+     *         one.
      */
     static Tessellator getThreadTesselator() {
         return TessellatorManager.get();

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/TessellatorManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/TessellatorManager.java
@@ -32,6 +32,10 @@ public class TessellatorManager {
         }
     }
 
+    public static boolean isCurrentlyCapturing() {
+        return currentlyCapturing.get();
+    }
+
     public static boolean isOnMainThread() {
         return Thread.currentThread() == mainThread;
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/compat/FalseTweaks.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/compat/FalseTweaks.java
@@ -1,0 +1,14 @@
+package com.gtnewhorizon.gtnhlib.compat;
+
+import com.falsepattern.falsetweaks.api.ThreadedChunkUpdates;
+
+public class FalseTweaks {
+
+    /**
+     * When FalseTweaks is loaded, it may inject into the Tesselator to do its own threaded chunk building. If it's
+     * doing that, disable our checks and let FT handle it.
+     */
+    public static boolean doTessSafetyChecks() {
+        return !ThreadedChunkUpdates.isEnabled();
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/compat/Mods.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/compat/Mods.java
@@ -3,5 +3,6 @@ package com.gtnewhorizon.gtnhlib.compat;
 import cpw.mods.fml.common.Loader;
 
 public class Mods {
+
     public static final boolean FALSETWEAKS = Loader.isModLoaded("falsetweaks");
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/compat/Mods.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/compat/Mods.java
@@ -1,0 +1,7 @@
+package com.gtnewhorizon.gtnhlib.compat;
+
+import cpw.mods.fml.common.Loader;
+
+public class Mods {
+    public static final boolean FALSETWEAKS = Loader.isModLoaded("falsetweaks");
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -14,7 +14,7 @@ import cpw.mods.fml.relauncher.FMLLaunchHandler;
 
 public enum Mixins {
 
-    TESSELLATOR(new Builder("Sodium").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT).setPhase(Phase.EARLY)
+    TESSELLATOR(new Builder("Thread safety checks for the Tesselator").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT).setPhase(Phase.EARLY)
             .setApplyIf(() -> true).addMixinClasses("MixinTessellator")),
     WAVEFRONT_VBO(new Builder("WavefrontObject").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)
             .setPhase(Phase.EARLY).setApplyIf(() -> true).addMixinClasses("MixinWavefrontObject")),

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -14,8 +14,8 @@ import cpw.mods.fml.relauncher.FMLLaunchHandler;
 
 public enum Mixins {
 
-    TESSELLATOR(new Builder("Thread safety checks for the Tesselator").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT).setPhase(Phase.EARLY)
-            .setApplyIf(() -> true).addMixinClasses("MixinTessellator")),
+    TESSELLATOR(new Builder("Thread safety checks for the Tesselator").addTargetedMod(TargetedMod.VANILLA)
+            .setSide(Side.CLIENT).setPhase(Phase.EARLY).setApplyIf(() -> true).addMixinClasses("MixinTessellator")),
     WAVEFRONT_VBO(new Builder("WavefrontObject").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)
             .setPhase(Phase.EARLY).setApplyIf(() -> true).addMixinClasses("MixinWavefrontObject")),
     GUI_MOD_LIST(new Builder("Auto config ui").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTessellator.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTessellator.java
@@ -1,5 +1,7 @@
 package com.gtnewhorizon.gtnhlib.mixins.early;
 
+import static com.gtnewhorizon.gtnhlib.ClientProxy.doThreadSafetyChecks;
+
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
@@ -18,8 +20,6 @@ import com.gtnewhorizon.gtnhlib.client.renderer.TessellatorManager;
 @Mixin(Tessellator.class)
 public abstract class MixinTessellator implements ITessellatorInstance {
 
-    @Shadow
-    public int vertexCount;
     @Shadow
     public boolean isDrawing;
 
@@ -40,7 +40,7 @@ public abstract class MixinTessellator implements ITessellatorInstance {
 
     @Inject(method = "draw", at = @At("HEAD"))
     private void preventOffMainThreadDrawing(CallbackInfoReturnable<Integer> cir) {
-        if (!TessellatorManager.isMainInstance(this)) {
+        if (doThreadSafetyChecks && !TessellatorManager.isMainInstance(this)) {
             throw new RuntimeException("Tried to draw on a tessellator that isn't on the main thread!");
         }
     }


### PR DESCRIPTION
If FT's threaded rendering is running, it's handling the safety checks itself so skip ours.