### PR TITLE
Add an interface for meta- and nbt-aware music disks to fix modded disk support in electric jukeboxes

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/MusicRecordMetadataProvider.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/MusicRecordMetadataProvider.java
@@ -1,0 +1,33 @@
+package com.gtnewhorizon.gtnhlib.api;
+
+import java.util.Collections;
+
+import net.minecraft.item.ItemRecord;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+/**
+ * Implement on classes extending {@link ItemRecord} to provide metadata and NBT-aware versions of the standard music
+ * metadata for use by other mods that implement custom jukeboxes.
+ */
+public interface MusicRecordMetadataProvider {
+
+    /**
+     * @param stack The ItemStack to get the sound resource for.
+     * @return The ResourceLocation of the sound this record plays, or {@code null} if none.
+     */
+    default ResourceLocation getMusicRecordResource(ItemStack stack) {
+        if (stack == null || stack.getItem() != this) {
+            return null;
+        }
+        final ItemRecord self = (ItemRecord) this;
+        return self.getRecordResource(self.recordName);
+    }
+
+    /**
+     * @return A list of all variants of this music record item that have playable music.
+     */
+    default Iterable<ItemStack> getMusicRecordVariants() {
+        return Collections.singleton(new ItemStack((ItemRecord) this, 1, 0));
+    }
+}


### PR DESCRIPTION
First part of fixing https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18055 - adding a standardized interface to list all music disks and get the sound resources corresponding to each disk, even for NBT and metadata-powered disks.