### PR TITLE
Automatic LoreHolder Discovery

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
@@ -30,11 +30,6 @@ public class ClientProxy extends CommonProxy {
     private final Minecraft mc = Minecraft.getMinecraft();
 
     @Override
-    public void preInit(FMLPreInitializationEvent event) {
-        super.preInit(event);
-    }
-
-    @Override
     public void init(FMLInitializationEvent event) {
         super.init(event);
         ClientCommandHandler.instance.registerCommand(new ItemInHandCommand());
@@ -57,31 +52,6 @@ public class ClientProxy extends CommonProxy {
         }
 
         LoreHandler.postInit();
-    }
-
-    @Override
-    public void serverAboutToStart(FMLServerAboutToStartEvent event) {
-        super.serverAboutToStart(event);
-    }
-
-    @Override
-    public void serverStarting(FMLServerStartingEvent event) {
-        super.serverStarting(event);
-    }
-
-    @Override
-    public void serverStarted(FMLServerStartedEvent event) {
-        super.serverStarted(event);
-    }
-
-    @Override
-    public void serverStopping(FMLServerStoppingEvent event) {
-        super.serverStopping(event);
-    }
-
-    @Override
-    public void serverStopped(FMLServerStoppedEvent event) {
-        super.serverStopped(event);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/tooltip/LoreHolder.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/tooltip/LoreHolder.java
@@ -7,7 +7,11 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation used to identify fields which should be updated on a resource refresh. Annotated fields must be static and
- * of type {@link String}. To use this, register the declaring class via {@link LoreHandler#registerLoreHolder(Class)}.
+ * of type {@link String}. When the resources are reloaded, the field(s) are updated with a random translation. The
+ * possible lines are defined via lang files, using the translation key defined by {@link #value()}, appended by an
+ * index (starting with 0). Blank translations are ignored. The translations may be weighted by using {@code <weight>:}
+ * as prefix, {@code <weight>} being a non-negative integer. If no weight is specified, a default value of 1 is used. To
+ * prevent ':' being used as delimiter, escape it using '\'.
  *
  * @since 0.5.21
  * @author glowredman

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/tooltip/LoreHolderDiscoverer.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/tooltip/LoreHolderDiscoverer.java
@@ -36,7 +36,9 @@ public class LoreHolderDiscoverer {
             try {
                 field = Fields.ofClass(clazz).getField(LookupType.DECLARED, fieldName, String.class);
             } catch (ClassCastException e) {
-                GTNHLib.LOG.error("Field " + fieldName + " of class " + className + " is not of type java.lang.String!", e);
+                GTNHLib.LOG.error(
+                        "Field " + fieldName + " of class " + className + " is not of type java.lang.String!",
+                        e);
                 continue;
             }
             if (field == null) {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/tooltip/LoreHolderDiscoverer.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/tooltip/LoreHolderDiscoverer.java
@@ -1,0 +1,57 @@
+package com.gtnewhorizon.gtnhlib.client.tooltip;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.gtnewhorizon.gtnhlib.GTNHLib;
+import com.gtnewhorizon.gtnhlib.reflect.Fields;
+import com.gtnewhorizon.gtnhlib.reflect.Fields.ClassFields;
+import com.gtnewhorizon.gtnhlib.reflect.Fields.LookupType;
+
+import cpw.mods.fml.common.discovery.ASMDataTable;
+import cpw.mods.fml.common.discovery.ASMDataTable.ASMData;
+
+public class LoreHolderDiscoverer {
+
+    /**
+     * key: field to be updated; value: translation key to use
+     */
+    static final Map<ClassFields<?>.Field<String>, String> LORE_HOLDERS = new HashMap<>();
+
+    public static void harvestData(ASMDataTable table) {
+        for (ASMData asmData : table.getAll(LoreHolder.class.getName())) {
+            String className = asmData.getClassName();
+            Class<?> clazz;
+            try {
+                clazz = Class.forName(className);
+            } catch (ClassNotFoundException e) {
+                GTNHLib.LOG.error("Class " + className + " could not be found!", e);
+                continue;
+            }
+
+            String fieldName = asmData.getObjectName();
+            ClassFields<?>.Field<String> field;
+            try {
+                field = Fields.ofClass(clazz).getField(LookupType.DECLARED, fieldName, String.class);
+            } catch (ClassCastException e) {
+                GTNHLib.LOG.error("Field " + fieldName + " of class " + className + " is not of type java.lang.String!", e);
+                continue;
+            }
+            if (field == null) {
+                GTNHLib.LOG.error("Field {} of class {} could not be found!", fieldName, className);
+                continue;
+            }
+            if (!field.isStatic) {
+                GTNHLib.LOG.error("Field {} of class {} is not static!", fieldName, className);
+                continue;
+            }
+
+            String key = (String) asmData.getAnnotationInfo().get("value");
+            if (StringUtils.isNotBlank(key)) {
+                LORE_HOLDERS.put(field, key);
+            }
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.service.mojang.MixinServiceLaunchWrapper;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.gtnewhorizon.gtnhlib.Tags;
+import com.gtnewhorizon.gtnhlib.client.tooltip.LoreHolderDiscoverer;
 import com.gtnewhorizon.gtnhlib.eventbus.EventBusUtil;
 import com.gtnewhorizon.gtnhlib.mixins.Mixins;
 import com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader;
@@ -94,5 +95,8 @@ public class GTNHLibCore extends DummyModContainer implements IFMLLoadingPlugin,
     @Subscribe
     public void construct(FMLConstructionEvent event) {
         EventBusUtil.harvestData(event.getASMHarvestedData());
+        if (event.getSide().isClient()) {
+            LoreHolderDiscoverer.harvestData(event.getASMHarvestedData());
+        }
     }
 }


### PR DESCRIPTION
Improves the LoreHolder system by identifying all fields during construction using FML's ASMDataTable. Previously, all classes containing one or more fields annotated with `@LoreHolder` would have been registered manually using `LoreHandler.registerLoreHolder()`.