### PR TITLE
Register config sync event bus in init

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigSyncHandler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigSyncHandler.java
@@ -10,7 +10,6 @@ import net.minecraft.server.integrated.IntegratedServer;
 
 import com.gtnewhorizon.gtnhlib.network.NetworkHandler;
 
-import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.common.network.FMLNetworkEvent;
@@ -22,10 +21,6 @@ public final class ConfigSyncHandler {
 
     static final Map<String, SyncedConfigElement> syncedElements = new Object2ObjectOpenHashMap<>();
     private static boolean hasSyncedValues = false;
-
-    static {
-        FMLCommonHandler.instance().bus().register(new ConfigSyncHandler());
-    }
 
     @SubscribeEvent
     public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import cpw.mods.fml.client.config.IConfigElement;
+import cpw.mods.fml.common.FMLCommonHandler;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.val;
@@ -490,6 +491,7 @@ public class ConfigurationManager {
     }
 
     public static void onInit() {
+        FMLCommonHandler.instance().bus().register(new ConfigSyncHandler());
         cullDeadCategories();
         if (DUMP_KEYS) {
             writeLangKeysToFile();


### PR DESCRIPTION
I forgot that loads of mods register their config in coremod and it kinda broke down crying when I tried using config sync in one of those mods