### PR TITLE
Fix MC keybinding-backed synced keybind listeners

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/keybind/SyncedKeybind.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/keybind/SyncedKeybind.java
@@ -50,7 +50,7 @@ public final class SyncedKeybind {
     @SideOnly(Side.CLIENT)
     private KeyBinding keybinding;
     @SideOnly(Side.CLIENT)
-    private int keyCode;
+    private int keyCode = -1;
     @SideOnly(Side.CLIENT)
     private boolean isKeyDown;
 
@@ -224,8 +224,10 @@ public final class SyncedKeybind {
         IntList updatingPressed = new IntArrayList();
         for (var entry : KEYBINDS.int2ObjectEntrySet()) {
             SyncedKeybind keybind = entry.getValue();
-            if (keybind.keybinding != null && keybind.keybinding.isPressed()) {
-                updatingPressed.add(entry.getIntKey());
+            if (keybind.keybinding != null) {
+                if (keybind.keybinding.isPressed()) {
+                    updatingPressed.add(entry.getIntKey());
+                }
             } else if (Keyboard.getEventKey() == keybind.keyCode) {
                 updatingPressed.add(entry.getIntKey());
             }


### PR DESCRIPTION
Fixes the lwjgl keyboard event key still being checked sometimes when a MC keybinding is set, which shouldn't happen. Also sets the key code to -1 by default, to avoid any other potential oddities