### PR TITLE
Add NEI Version Check

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -176,7 +176,7 @@ curseForgeRelations =
 # This can be useful if you e.g. only want to allow versions in the form of '1.1.xxx'.
 # The check is ONLY performed if the version is a git tag.
 # Note: the specified string must be escaped, so e.g. 1\\.1\\.\\d+ instead of 1\.1\.\d+
-# versionPattern =
+versionPattern = d+\\.d+\\.d+(-pre|-snapshot)?
 
 # Uncomment to prevent the source code from being published.
 # noPublishedSources = true

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.31'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.32'
 }
 
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
@@ -13,9 +13,11 @@ import com.gtnewhorizon.gtnhlib.client.tooltip.LoreHandler;
 import com.gtnewhorizon.gtnhlib.commands.ItemInHandCommand;
 import com.gtnewhorizon.gtnhlib.compat.FalseTweaks;
 import com.gtnewhorizon.gtnhlib.compat.Mods;
+import com.gtnewhorizon.gtnhlib.compat.NotEnoughItemsVersionChecker;
 import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
 import com.gtnewhorizon.gtnhlib.util.AboveHotbarHUD;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.*;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
@@ -44,6 +46,9 @@ public class ClientProxy extends CommonProxy {
             if (!doThreadSafetyChecks) {
                 GTNHLib.info("FalseTweaks threaded rendering is enabled - disabling GTNHLib's thread safety checks");
             }
+        }
+        if (Mods.NEI) {
+            FMLCommonHandler.instance().bus().register(new NotEnoughItemsVersionChecker());
         }
 
         if (shouldLoadModels()) {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.IChatComponent;
 import net.minecraftforge.common.util.FakePlayer;
 
+import com.gtnewhorizon.gtnhlib.config.ConfigException;
 import com.gtnewhorizon.gtnhlib.config.ConfigurationManager;
 import com.gtnewhorizon.gtnhlib.eventbus.AutoEventBus;
 import com.gtnewhorizon.gtnhlib.eventbus.Phase;
@@ -29,6 +30,11 @@ public class CommonProxy {
     public void preInit(FMLPreInitializationEvent event) {
         AutoEventBus.executePhase(Phase.PRE);
         GTNHLib.info("GTNHLib version " + Tags.VERSION + " loaded.");
+        try {
+            ConfigurationManager.registerConfig(GTNHLibConfig.class);
+        } catch (ConfigException e) {
+            GTNHLib.LOG.error("Failed to register GTNHLib config!", e);
+        }
     }
 
     public void init(FMLInitializationEvent event) {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLibConfig.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLibConfig.java
@@ -1,0 +1,12 @@
+package com.gtnewhorizon.gtnhlib;
+
+import com.gtnewhorizon.gtnhlib.config.Config;
+
+@Config(modid = GTNHLib.MODID)
+public class GTNHLibConfig {
+
+    @Config.Comment("Set to true to no longer check if the NEI version is new enough to support RenderTooltipEvents")
+    @Config.DefaultBoolean(false)
+    public static boolean ignoreNEIVersion;
+
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/compat/Mods.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/compat/Mods.java
@@ -5,4 +5,5 @@ import cpw.mods.fml.common.Loader;
 public class Mods {
 
     public static final boolean FALSETWEAKS = Loader.isModLoaded("falsetweaks");
+    public static final boolean NEI = Loader.isModLoaded("NotEnoughItems");
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/compat/NotEnoughItemsVersionChecker.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/compat/NotEnoughItemsVersionChecker.java
@@ -1,0 +1,40 @@
+package com.gtnewhorizon.gtnhlib.compat;
+
+import java.util.Locale;
+
+import com.gtnewhorizon.gtnhlib.GTNHLib;
+import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
+
+import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent.ClientTickEvent;
+import cpw.mods.fml.common.versioning.ArtifactVersion;
+import cpw.mods.fml.common.versioning.DefaultArtifactVersion;
+
+public class NotEnoughItemsVersionChecker {
+
+    @SubscribeEvent
+    public void checkNEIVersion(ClientTickEvent event) {
+        if (FMLClientHandler.instance().getClient().thePlayer == null) {
+            return;
+        }
+
+        FMLCommonHandler.instance().bus().unregister(this);
+
+        if (GTNHLibConfig.ignoreNEIVersion) {
+            return;
+        }
+
+        ArtifactVersion neiVersion = Loader.instance().getIndexedModList().get("NotEnoughItems").getProcessedVersion();
+        if (neiVersion.compareTo(new DefaultArtifactVersion("2.7.8-GTNH")) >= 0) {
+            return; // NEI is at least version 2.7.8-GTNH
+        }
+        GTNHLib.proxy.addWarnToChat(
+                String.format(
+                        Locale.ROOT,
+                        "Installed NEI version is to old to support RenderTooltipEvents! This may cause problems. Installed NEI version: %s (2.7.8-GTNH and newer support RenderTooltipEvents)",
+                        neiVersion.getVersionString()));
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/FilesUtil.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/FilesUtil.java
@@ -3,6 +3,8 @@ package com.gtnewhorizon.gtnhlib.util;
 import java.io.IOException;
 import java.net.URI;
 
+import net.minecraft.util.Util;
+
 import org.lwjgl.Sys;
 
 import com.gtnewhorizon.gtnhlib.GTNHLib;
@@ -10,7 +12,7 @@ import com.gtnewhorizon.gtnhlib.GTNHLib;
 public class FilesUtil {
 
     public static void openUri(URI uri) {
-        switch (net.minecraft.util.Util.getOSType()) {
+        switch (Util.getOSType()) {
             case OSX -> {
                 try {
                     Runtime.getRuntime().exec(new String[] { "/usr/bin/open", uri.toString() });


### PR DESCRIPTION
This PR adds a check which runs the first time the player enters any world. If NEI is present and older than 2.7.8-GTNH, a warning will be printed to the chat informing the player that RenderTooltipEvents won't work. This check can be disabled via a config property. I favor this approach over simply adding `before:NotEnoughItems@[2.7.8-GTNH,)` in the `@Mod` annotation because this still allows the use of older NEI versions if RenderTooltipEvents aren't used.

This PR also sets `versionPattern` to prevent future mistakes in that area.