### PR TITLE
Add mixin to register LivingEquipmentChangeEvent

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/event/LivingEquipmentChangeEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/event/LivingEquipmentChangeEvent.java
@@ -5,6 +5,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.living.LivingEvent;
 
 public class LivingEquipmentChangeEvent extends LivingEvent {
+
     /*
      * Backported from github.com/MinecraftForge/MinecraftForge/pull/3411
      */
@@ -19,7 +20,8 @@ public class LivingEquipmentChangeEvent extends LivingEvent {
      * This event is fired on server-side only. <br>
      * <br>
      * {@link #slot} contains the index of the affected inventory slot. <br>
-     * {@link #from} contains the {@link ItemStack} that was equipped previously. <br>
+     * -0: Equipped in main hand -1: Boots -2: Leggings -3: Leggings -4: Helmet {@link #from} contains the
+     * {@link ItemStack} that was equipped previously. <br>
      * {@link #to} contains the {@link ItemStack} that is equipped now. <br>
      * <br>
      * This event is not {@link cpw.mods.fml.common.eventhandler.Cancelable}. <br>
@@ -29,15 +31,22 @@ public class LivingEquipmentChangeEvent extends LivingEvent {
      * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.
      **/
 
-    public LivingEquipmentChangeEvent(EntityLivingBase entity, int slot, ItemStack from, ItemStack to)
-    {
+    public LivingEquipmentChangeEvent(EntityLivingBase entity, int slot, ItemStack from, ItemStack to) {
         super(entity);
         this.slot = slot;
         this.from = from;
         this.to = to;
     }
 
-    public int getSlot() { return this.slot; }
-    public ItemStack getFrom() { return this.from; }
-    public ItemStack getTo() { return this.to; }
+    public int getSlot() {
+        return this.slot;
+    }
+
+    public ItemStack getFrom() {
+        return this.from;
+    }
+
+    public ItemStack getTo() {
+        return this.to;
+    }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/event/LivingEquipmentChangeEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/event/LivingEquipmentChangeEvent.java
@@ -19,9 +19,15 @@ public class LivingEquipmentChangeEvent extends LivingEvent {
      * This also includes entities joining the World, as well as being cloned. <br>
      * This event is fired on server-side only. <br>
      * <br>
-     * {@link #slot} contains the index of the affected inventory slot. <br>
-     * -0: Equipped in main hand -1: Boots -2: Leggings -3: Leggings -4: Helmet {@link #from} contains the
-     * {@link ItemStack} that was equipped previously. <br>
+     * {@link #slot} contains the index of the affected inventory slot.
+     * <ul>
+     * <li>0: Equipped in main hand
+     * <li>1: Boots
+     * <li>2: Leggings
+     * <li>3: Chestplate
+     * <li>4: Helmet
+     * </ul>
+     * {@link #from} contains the {@link ItemStack} that was equipped previously. <br>
      * {@link #to} contains the {@link ItemStack} that is equipped now. <br>
      * <br>
      * This event is not {@link cpw.mods.fml.common.eventhandler.Cancelable}. <br>
@@ -38,6 +44,16 @@ public class LivingEquipmentChangeEvent extends LivingEvent {
         this.to = to;
     }
 
+    /**
+     * @return index of the affected inventory slot.
+     *         <ul>
+     *         <li>0: Equipped in main hand
+     *         <li>1: Boots
+     *         <li>2: Leggings
+     *         <li>3: Chestplate
+     *         <li>4: Helmet
+     *         </ul>
+     */
     public int getSlot() {
         return this.slot;
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/event/LivingEquipmentChangeEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/event/LivingEquipmentChangeEvent.java
@@ -1,0 +1,43 @@
+package com.gtnewhorizon.gtnhlib.client.event;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.living.LivingEvent;
+
+public class LivingEquipmentChangeEvent extends LivingEvent {
+    /*
+     * Backported from github.com/MinecraftForge/MinecraftForge/pull/3411
+     */
+    private final int slot;
+    private final ItemStack from;
+    private final ItemStack to;
+
+    /**
+     * {@link LivingEquipmentChangeEvent} is fired when the Equipment of an Entity changes. <br>
+     * This event is fired whenever changes in Equipment are detected in {@link EntityLivingBase#onUpdate()}. <br>
+     * This also includes entities joining the World, as well as being cloned. <br>
+     * This event is fired on server-side only. <br>
+     * <br>
+     * {@link #slot} contains the index of the affected inventory slot. <br>
+     * {@link #from} contains the {@link ItemStack} that was equipped previously. <br>
+     * {@link #to} contains the {@link ItemStack} that is equipped now. <br>
+     * <br>
+     * This event is not {@link cpw.mods.fml.common.eventhandler.Cancelable}. <br>
+     * <br>
+     * This event does not have a result. {@link HasResult} <br>
+     * <br>
+     * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.
+     **/
+
+    public LivingEquipmentChangeEvent(EntityLivingBase entity, int slot, ItemStack from, ItemStack to)
+    {
+        super(entity);
+        this.slot = slot;
+        this.from = from;
+        this.to = to;
+    }
+
+    public int getSlot() { return this.slot; }
+    public ItemStack getFrom() { return this.from; }
+    public ItemStack getTo() { return this.to; }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -24,8 +24,9 @@ public enum Mixins {
             .setPhase(Phase.EARLY).addMixinClasses("fml.EventBusAccessor", "fml.EnumHolderAccessor")),
     TOOLTIP_RENDER(new Builder("TooltipRenderer").addMixinClasses("MixinGuiScreen").addTargetedMod(TargetedMod.VANILLA)
             .setApplyIf(() -> true).setPhase(Phase.EARLY).setSide(Side.CLIENT)),
-    EQUIPMENT_CHANGE_EVENT(new Builder("Add equipment change Forge events").addTargetedMod(TargetedMod.VANILLA).setSide(Side.SERVER)
-        .setPhase(Phase.EARLY).addMixinClasses("MixinEntityLivingBase").setApplyIf(() -> true)),
+    EQUIPMENT_CHANGE_EVENT(
+            new Builder("Add equipment change Forge events").addTargetedMod(TargetedMod.VANILLA).setSide(Side.SERVER)
+                    .setPhase(Phase.EARLY).addMixinClasses("MixinEntityLivingBase").setApplyIf(() -> true)),
     DEBUG_TEXTURES(new Builder("Dump textures sizes").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)
             .setPhase(Phase.EARLY)
             .setApplyIf(() -> Boolean.parseBoolean(System.getProperty("gtnhlib.debugtextures", "false")))

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -24,9 +24,8 @@ public enum Mixins {
             .setPhase(Phase.EARLY).addMixinClasses("fml.EventBusAccessor", "fml.EnumHolderAccessor")),
     TOOLTIP_RENDER(new Builder("TooltipRenderer").addMixinClasses("MixinGuiScreen").addTargetedMod(TargetedMod.VANILLA)
             .setApplyIf(() -> true).setPhase(Phase.EARLY).setSide(Side.CLIENT)),
-    EQUIPMENT_CHANGE_EVENT(
-            new Builder("Add equipment change Forge events").addTargetedMod(TargetedMod.VANILLA).setSide(Side.SERVER)
-                    .setPhase(Phase.EARLY).addMixinClasses("MixinEntityLivingBase").setApplyIf(() -> true)),
+    EQUIPMENT_CHANGE_EVENT(new Builder("Add equipment change Forge events").addTargetedMod(TargetedMod.VANILLA)
+            .setSide(Side.BOTH).setPhase(Phase.EARLY).addMixinClasses("MixinEntityLivingBase").setApplyIf(() -> true)),
     DEBUG_TEXTURES(new Builder("Dump textures sizes").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)
             .setPhase(Phase.EARLY)
             .setApplyIf(() -> Boolean.parseBoolean(System.getProperty("gtnhlib.debugtextures", "false")))

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -24,6 +24,8 @@ public enum Mixins {
             .setPhase(Phase.EARLY).addMixinClasses("fml.EventBusAccessor", "fml.EnumHolderAccessor")),
     TOOLTIP_RENDER(new Builder("TooltipRenderer").addMixinClasses("MixinGuiScreen").addTargetedMod(TargetedMod.VANILLA)
             .setApplyIf(() -> true).setPhase(Phase.EARLY).setSide(Side.CLIENT)),
+    EQUIPMENT_CHANGE_EVENT(new Builder("Add equipment change Forge events").addTargetedMod(TargetedMod.VANILLA).setSide(Side.SERVER)
+        .setPhase(Phase.EARLY).addMixinClasses("MixinEntityLivingBase").setApplyIf(() -> true)),
     DEBUG_TEXTURES(new Builder("Dump textures sizes").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)
             .setPhase(Phase.EARLY)
             .setApplyIf(() -> Boolean.parseBoolean(System.getProperty("gtnhlib.debugtextures", "false")))

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinEntityLivingBase.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinEntityLivingBase.java
@@ -1,20 +1,27 @@
 package com.gtnewhorizon.gtnhlib.mixins.early;
 
-import com.gtnewhorizon.gtnhlib.client.event.LivingEquipmentChangeEvent;
-import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.gtnewhorizon.gtnhlib.client.event.LivingEquipmentChangeEvent;
+import com.llamalad7.mixinextras.sugar.Local;
+
 @Mixin(EntityLivingBase.class)
 public class MixinEntityLivingBase {
 
-    @Inject(method = "onUpdate", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/WorldServer;getEntityTracker()Lnet/minecraft/entity/EntityTracker;"))
-    private void addEquipmentChangeEventBus(CallbackInfo ci, @Local(ordinal = 0) int slot, @Local (ordinal = 0) ItemStack prevItem, @Local (ordinal = 1) ItemStack newItem) {
-        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new LivingEquipmentChangeEvent((EntityLivingBase) (Object) this, slot, prevItem, newItem));
+    @Inject(
+            method = "onUpdate",
+            at = @At(
+                    value = "INVOKE_ASSIGN",
+                    target = "Lnet/minecraft/world/WorldServer;getEntityTracker()Lnet/minecraft/entity/EntityTracker;"))
+    private void addEquipmentChangeEventBus(CallbackInfo ci, @Local(ordinal = 1) int slot,
+            @Local(ordinal = 0) ItemStack prevItem, @Local(ordinal = 1) ItemStack newItem) {
+        net.minecraftforge.common.MinecraftForge.EVENT_BUS
+                .post(new LivingEquipmentChangeEvent((EntityLivingBase) (Object) this, slot, prevItem, newItem));
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinEntityLivingBase.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinEntityLivingBase.java
@@ -1,0 +1,20 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import com.gtnewhorizon.gtnhlib.client.event.LivingEquipmentChangeEvent;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityLivingBase.class)
+public class MixinEntityLivingBase {
+
+    @Inject(method = "onUpdate", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/WorldServer;getEntityTracker()Lnet/minecraft/entity/EntityTracker;"))
+    private void addEquipmentChangeEventBus(CallbackInfo ci, @Local(ordinal = 0) int slot, @Local (ordinal = 0) ItemStack prevItem, @Local (ordinal = 1) ItemStack newItem) {
+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new LivingEquipmentChangeEvent((EntityLivingBase) (Object) this, slot, prevItem, newItem));
+    }
+}


### PR DESCRIPTION
Adds a forge event which is fired whenever a LivingEntity updates their equipment (armor or main hand item)

This is backported from https://github.com/MinecraftForge/MinecraftForge/pull/3411/ and will be used for armor effects in GTNH.

Short image explanation of the mixin target: 
![image](https://github.com/user-attachments/assets/2d20fce4-42af-448a-9652-d51fec1c2d9e)
