### PR TITLE
Make BlockPos modifications return BlockPos instead of IBlockPos

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/blockpos/BlockPos.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/blockpos/BlockPos.java
@@ -40,17 +40,17 @@ public class BlockPos extends Vector3i implements IMutableBlockPos {
     }
 
     @Override
-    public IBlockPos offset(ForgeDirection d) {
+    public BlockPos offset(ForgeDirection d) {
         return new BlockPos(this.x + d.offsetX, this.y + d.offsetY, this.z + d.offsetZ);
     }
 
     @Override
-    public IBlockPos down() {
+    public BlockPos down() {
         return offset(ForgeDirection.DOWN);
     }
 
     @Override
-    public IBlockPos up() {
+    public BlockPos up() {
         return offset(ForgeDirection.UP);
     }
 


### PR DESCRIPTION
This PR replaces the return type of methods in BlockPos, but not changing the IBlockPos interface.
Idk if it ABI compat, but it does API compat.

This fixes the problem that you'll need to cast the return values to BlockPos, when you maintaining a Collection of BlockPos.
In newer forges/fabrics (e.g.: 1.12.2), there isn't a IBlockPos interface, so all methods return BlockPos. It is misleading.

And one more reason is that, BlockPos is _mutable_, so at least the return types should be `IMutableBlockPos` instead of `IBlockPos`, because it loses the set methods.