### PR TITLE
Added offset(int, int, int) and copy() for BlockPos

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/blockpos/BlockPos.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/blockpos/BlockPos.java
@@ -45,6 +45,11 @@ public class BlockPos extends Vector3i implements IMutableBlockPos {
     }
 
     @Override
+    public BlockPos offset(int x, int y, int z) {
+        return new BlockPos(this.x + x, this.y + y, this.z + z);
+    }
+
+    @Override
     public BlockPos down() {
         return offset(ForgeDirection.DOWN);
     }
@@ -52,6 +57,11 @@ public class BlockPos extends Vector3i implements IMutableBlockPos {
     @Override
     public BlockPos up() {
         return offset(ForgeDirection.UP);
+    }
+
+    @Override
+    public BlockPos copy() {
+        return new BlockPos(this.x, this.y, this.z);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/gtnhlib/blockpos/IBlockPos.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/blockpos/IBlockPos.java
@@ -14,9 +14,13 @@ public interface IBlockPos {
 
     IBlockPos offset(ForgeDirection d);
 
+    IBlockPos offset(int x, int y, int z);
+
     IBlockPos down();
 
     IBlockPos up();
+
+    IBlockPos copy();
 
     long asLong();
 


### PR DESCRIPTION
This PR adds `#offset(int, int, int)` and `#copy()` to BlockPos, because they are missing.