### PR TITLE
Backport callFromMainThread() and addScheduledTask()

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -29,7 +29,9 @@ public enum Mixins {
     DEBUG_TEXTURES(new Builder("Dump textures sizes").addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT)
             .setPhase(Phase.EARLY)
             .setApplyIf(() -> Boolean.parseBoolean(System.getProperty("gtnhlib.debugtextures", "false")))
-            .addMixinClasses("debug.MixinDynamicTexture", "debug.MixinTextureAtlasSprite"));
+            .addMixinClasses("debug.MixinDynamicTexture", "debug.MixinTextureAtlasSprite")),
+    SERVER_TICKING(new Builder("Backport MinecraftServer ticking methods").addTargetedMod(TargetedMod.VANILLA)
+            .setSide(Side.BOTH).setPhase(Phase.EARLY).addMixinClasses("MixinMinecraftServer").setApplyIf(() -> true));
 
     private final List<String> mixinClasses;
     private final Supplier<Boolean> applyIf;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -26,7 +26,7 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.EARLY)
             .setApplyIf(() -> Boolean.parseBoolean(System.getProperty("gtnhlib.debugtextures", "false")))
             .addMixinClasses("debug.MixinDynamicTexture", "debug.MixinTextureAtlasSprite")),
-    SERVER_TICKING(new Builder("Backport MinecraftServer ticking methods").addTargetedMod(TargetedMod.VANILLA)
+    SERVER_TICKING(new MixinBuilder("Backport MinecraftServer ticking methods").addTargetedMod(TargetedMod.VANILLA)
             .setSide(Side.BOTH).setPhase(Phase.EARLY).addMixinClasses("MixinMinecraftServer").setApplyIf(() -> true));
 
     private final List<String> mixinClasses;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinMinecraftServer.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinMinecraftServer.java
@@ -30,4 +30,9 @@ public class MixinMinecraftServer {
         ServerThreadUtil.setup((MinecraftServer) (Object) this, Thread.currentThread());
     }
 
+    @Inject(method = "run", at = @At("RETURN"))
+    private void clearServerThreadReference(CallbackInfo ci) {
+        ServerThreadUtil.clear();
+    }
+
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinMinecraftServer.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinMinecraftServer.java
@@ -1,0 +1,33 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import net.minecraft.profiler.Profiler;
+import net.minecraft.server.MinecraftServer;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizon.gtnhlib.util.ServerThreadUtil;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+
+    @Shadow
+    @Final
+    public Profiler theProfiler;
+
+    @Inject(method = "updateTimeLightAndEntities", at = @At("HEAD"))
+    private void runJobs(CallbackInfo ci) {
+        this.theProfiler.startSection("jobs");
+        ServerThreadUtil.runJobs();
+    }
+
+    @Inject(method = "run", at = @At("HEAD"))
+    private void saveServerThreadReference(CallbackInfo ci) {
+        ServerThreadUtil.setup((MinecraftServer) (Object) this, Thread.currentThread());
+    }
+
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/ServerThreadUtil.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/ServerThreadUtil.java
@@ -47,6 +47,13 @@ public class ServerThreadUtil {
         ServerThreadUtil.serverThread = serverThread;
     }
 
+    @ApiStatus.Internal
+    public static void clear() {
+        futureTaskQueue.clear();
+        ServerThreadUtil.server = null;
+        ServerThreadUtil.serverThread = null;
+    }
+
     public static boolean isCallingFromMinecraftThread() {
         return Thread.currentThread() == serverThread;
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/ServerThreadUtil.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/ServerThreadUtil.java
@@ -1,0 +1,78 @@
+package com.gtnewhorizon.gtnhlib.util;
+
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+
+import net.minecraft.server.MinecraftServer;
+
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.ApiStatus;
+
+import com.google.common.collect.Queues;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
+
+@SuppressWarnings("UnstableApiUsage")
+public class ServerThreadUtil {
+
+    private static final Logger logger = LogManager.getLogger();
+    private static final Queue<FutureTask<?>> futureTaskQueue = Queues.newArrayDeque();
+    private static MinecraftServer server;
+    private static Thread serverThread;
+
+    @ApiStatus.Internal
+    public static void runJobs() {
+        synchronized (futureTaskQueue) {
+            while (!futureTaskQueue.isEmpty()) {
+                FutureTask<?> task = futureTaskQueue.poll();
+                try {
+                    task.run();
+                    task.get(); // result is ignored
+                } catch (ExecutionException | InterruptedException e) {
+                    logger.error("Error executing task", e);
+                }
+            }
+        }
+    }
+
+    @ApiStatus.Internal
+    public static void setup(MinecraftServer server, Thread serverThread) {
+        ServerThreadUtil.server = server;
+        ServerThreadUtil.serverThread = serverThread;
+    }
+
+    public static boolean isCallingFromMinecraftThread() {
+        return Thread.currentThread() == serverThread;
+    }
+
+    public static <V> ListenableFuture<V> callFromMainThread(Callable<V> callable) {
+        Validate.notNull(callable);
+
+        if (!isCallingFromMinecraftThread() && !server.isServerStopped()) {
+            ListenableFutureTask<V> listenableFutureTask = ListenableFutureTask.create(callable);
+
+            synchronized (futureTaskQueue) {
+                futureTaskQueue.add(listenableFutureTask);
+                return listenableFutureTask;
+            }
+        } else {
+            try {
+                return Futures.immediateFuture(callable.call());
+            } catch (Exception e) {
+                return Futures.immediateFailedCheckedFuture(e);
+            }
+        }
+    }
+
+    public static ListenableFuture<Object> addScheduledTask(Runnable runnableToSchedule) {
+        Validate.notNull(runnableToSchedule);
+        return callFromMainThread(Executors.callable(runnableToSchedule));
+    }
+
+}


### PR DESCRIPTION
Backport callFromMainThread() and addScheduledTask() of MinecraftServer from 1.12.2

The executing timing is exactly same to what 1.12 Forge does.
And because of my Mixin knowledge limit, I can only get the server thread like that.

These functions are used to do something in server thread, submitted from other threads, like async tasks. (although it checks if the calling thread is the server thread, like 1.12 does)
