### PR TITLE
Add convenience method to ObjectPooler

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.function.Supplier;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjectPooler<T> {
 
@@ -28,11 +29,14 @@ public class ObjectPooler<T> {
     }
 
     public void releaseInstances(Collection<T> instances) {
-        this.availableInstances.addAll(instances);
+        instances.forEach(i -> { if (i != null) { releaseInstance(i); }});
         instances.clear();
     }
 
-    public void releaseInstances(T[] instances) {
+    /**
+     * Uses arraycopy instead of a loop. Faster, but doesn't check that the input is nonnull. Use with care!
+     */
+    public void releaseInstances(@NotNull T[] instances) {
         this.availableInstances.addElements(availableInstances.size(), instances);
         Arrays.fill(instances, null);
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
@@ -1,17 +1,18 @@
 package com.gtnewhorizon.gtnhlib.util;
 
-import java.util.ArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
 
 public class ObjectPooler<T> {
 
     private final Supplier<T> instanceSupplier;
-    private final ArrayList<T> availableInstances;
+    private final ObjectArrayList<T> availableInstances;
 
     public ObjectPooler(Supplier<T> instanceSupplier) {
         this.instanceSupplier = instanceSupplier;
-        this.availableInstances = new ArrayList<>();
+        this.availableInstances = new ObjectArrayList<>();
     }
 
     public T getInstance() {
@@ -28,5 +29,10 @@ public class ObjectPooler<T> {
     public void releaseInstances(Collection<T> instances) {
         this.availableInstances.addAll(instances);
         instances.clear();
+    }
+
+    public void releaseInstances(T[] instances) {
+        this.availableInstances.addElements(availableInstances.size(), instances);
+        Arrays.fill(instances, null);
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
@@ -1,6 +1,7 @@
 package com.gtnewhorizon.gtnhlib.util;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.function.Supplier;
 
 public class ObjectPooler<T> {
@@ -22,5 +23,10 @@ public class ObjectPooler<T> {
 
     public void releaseInstance(T instance) {
         this.availableInstances.add(instance);
+    }
+
+    public void releaseInstances(Collection<T> instances) {
+        this.availableInstances.addAll(instances);
+        instances.clear();
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
@@ -26,15 +26,12 @@ public class ObjectPooler<T> {
     }
 
     public void releaseInstance(T instance) {
+        if (instance == null) return;
         this.availableInstances.add(instance);
     }
 
     public void releaseInstances(Collection<T> instances) {
-        instances.forEach(i -> {
-            if (i != null) {
-                releaseInstance(i);
-            }
-        });
+        instances.forEach(this::releaseInstance);
         instances.clear();
     }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
@@ -1,9 +1,10 @@
 package com.gtnewhorizon.gtnhlib.util;
 
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 
 public class ObjectPooler<T> {
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/ObjectPooler.java
@@ -4,8 +4,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.jetbrains.annotations.NotNull;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 
 public class ObjectPooler<T> {
 
@@ -29,7 +30,11 @@ public class ObjectPooler<T> {
     }
 
     public void releaseInstances(Collection<T> instances) {
-        instances.forEach(i -> { if (i != null) { releaseInstance(i); }});
+        instances.forEach(i -> {
+            if (i != null) {
+                releaseInstance(i);
+            }
+        });
         instances.clear();
     }
 


### PR DESCRIPTION
Release whole collections at once, instead of having to iteratively do it.