### PR TITLE
Add getter for KeyBinding in SyncedKeybind

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/keybind/SyncedKeybind.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/keybind/SyncedKeybind.java
@@ -233,4 +233,9 @@ public final class SyncedKeybind {
     public int getKeyCode() {
         return keybinding != null ? keybinding.getKeyCode() : keyCode;
     }
+
+    @SideOnly(Side.CLIENT)
+    public KeyBinding getKeybinding() {
+        return keybinding;
+    }
 }


### PR DESCRIPTION
I want to be able to get the name of a keybind from a SyncedKeybind for modular armor