### PR TITLE
Add ITranslucentItem for translucent item support

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLibConfig.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLibConfig.java
@@ -29,6 +29,10 @@ public class GTNHLibConfig {
     @Config.RequiresMcRestart
     public static boolean blockSoundMixins;
 
+    @Config.Comment("Enable item rendering modifications to allow rendering some items as translucent")
+    @Config.DefaultBoolean(true)
+    public static boolean enableTranslucentItemRenders;
+
     @Config.Comment("If you're not a dev, you don't need this")
     @Config.DefaultBoolean(false)
     @Config.RequiresMcRestart

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/ITranslucentItem.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/ITranslucentItem.java
@@ -1,0 +1,8 @@
+package com.gtnewhorizon.gtnhlib.api;
+
+/**
+ * Implement on {@link net.minecraft.item.Item}s to enable them to be rendered with translucency in 3d. E.g. Utilities
+ * In Excess's inverted ingot & tools.
+ */
+public interface ITranslucentItem {
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -45,6 +45,9 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> GTNHLibConfig.blockSoundMixins)),
     ENTITY_RENDERER_ACCESSOR(new MixinBuilder("Accesses the lightmap property of EntityRenderer").setPhase(Phase.EARLY)
             .addCommonMixins("EntityRendererAccessor")),
+    ITEM_TRANSLUCENCY(new MixinBuilder("ItemRenderer & RenderItem ITranslucentItem support")
+            .addClientMixins("MixinItemRenderer_Translucency", "MixinRenderItem_Translucency").setPhase(Phase.EARLY)
+            .setApplyIf(() -> GTNHLibConfig.enableTranslucentItemRenders)),
     //
     ;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinItemRenderer_Translucency.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinItemRenderer_Translucency.java
@@ -1,0 +1,28 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import net.minecraft.client.renderer.ItemRenderer;
+import net.minecraft.item.ItemCloth;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.gtnewhorizon.gtnhlib.api.ITranslucentItem;
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+
+@Mixin(ItemRenderer.class)
+public class MixinItemRenderer_Translucency {
+
+    @Definition(id = "getItem", method = "Lnet/minecraft/item/ItemStack;getItem()Lnet/minecraft/item/Item;")
+    @Definition(id = "itemstack", local = @Local(type = ItemStack.class))
+    @Definition(id = "ItemCloth", type = ItemCloth.class)
+    @Expression("itemstack.getItem() instanceof ItemCloth")
+    @WrapOperation(method = "renderItemInFirstPerson", at = @At(value = "MIXINEXTRAS:EXPRESSION"))
+    private boolean gtnhlib$isItemTranslucent(Object object, Operation<Boolean> original) {
+        return object instanceof ITranslucentItem || original.call(object);
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderItem_Translucency.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderItem_Translucency.java
@@ -1,0 +1,30 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import net.minecraft.client.renderer.entity.RenderItem;
+import net.minecraft.item.ItemCloth;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.gtnewhorizon.gtnhlib.api.ITranslucentItem;
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+
+@Mixin(RenderItem.class)
+public class MixinRenderItem_Translucency {
+
+    @Definition(id = "getItem", method = "Lnet/minecraft/item/ItemStack;getItem()Lnet/minecraft/item/Item;")
+    @Definition(id = "itemstack", local = @Local(type = ItemStack.class))
+    @Definition(id = "ItemCloth", type = ItemCloth.class)
+    @Expression("itemstack.getItem() instanceof ItemCloth")
+    @WrapOperation(
+            method = "doRender(Lnet/minecraft/entity/item/EntityItem;DDDFF)V",
+            at = @At(value = "MIXINEXTRAS:EXPRESSION"))
+    private boolean gtnhlib$isItemTranslucent(Object object, Operation<Boolean> original) {
+        return object instanceof ITranslucentItem || original.call(object);
+    }
+}

--- a/src/main/resources/mixins.gtnhlib.early.json
+++ b/src/main/resources/mixins.gtnhlib.early.json
@@ -4,6 +4,9 @@
   "package": "com.gtnewhorizon.gtnhlib.mixins.early",
   "refmap": "mixins.gtnhlib.refmap.json",
   "target": "@env(DEFAULT)",
+  "mixinextras": {
+    "minVersion": "0.5.0"
+  },
   "compatibilityLevel": "JAVA_8"
 }
 


### PR DESCRIPTION
Currently items need custom renderers that replicate the vanilla renderer to be translucent. so I made this for utilities in excess for inverted tools, And we want to use it for tinker's tools as well
mixinextras refuses to let the game start unless I also add the dependency to the mixins json
<img width="730" height="763" alt="image" src="https://github.com/user-attachments/assets/960ae934-dff5-4c44-a081-e3135dca6156" />
<img width="274" height="260" alt="image" src="https://github.com/user-attachments/assets/5f22ac3d-4e4b-4bbd-b12a-9ea19e6552dd" />
