### PR TITLE
Initialize UniversiumShader only when needed

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
@@ -15,7 +15,6 @@ import net.minecraftforge.common.MinecraftForge;
 
 import com.gtnewhorizon.gtnhlib.client.model.ModelISBRH;
 import com.gtnewhorizon.gtnhlib.client.model.loading.ModelRegistry;
-import com.gtnewhorizon.gtnhlib.client.renderer.postprocessing.shaders.UniversiumShader;
 import com.gtnewhorizon.gtnhlib.client.tooltip.LoreHandler;
 import com.gtnewhorizon.gtnhlib.commands.ItemInHandCommand;
 import com.gtnewhorizon.gtnhlib.compat.FalseTweaks;
@@ -57,7 +56,6 @@ public class ClientProxy extends CommonProxy {
     public void init(FMLInitializationEvent event) {
         super.init(event);
         ClientCommandHandler.instance.registerCommand(new ItemInHandCommand());
-        UniversiumShader.init();
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/postprocessing/shaders/UniversiumShader.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/postprocessing/shaders/UniversiumShader.java
@@ -94,11 +94,10 @@ public final class UniversiumShader extends ShaderProgram {
     }
 
     public static UniversiumShader getInstance() {
+        if (instance == null) {
+            instance = new UniversiumShader();
+        }
         return instance;
-    }
-
-    public static void init() {
-        instance = new UniversiumShader();
     }
 
     @SubscribeEvent


### PR DESCRIPTION
For whatever reason, I sometimes had issues with the splash & title screen. Since I didn't get an error or anything, I'll just move the loading to whenever it's needed. Loading times of the shader are low anyway so it pretty much makes no difference.