### PR TITLE
Adds pick block event mixin

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/event/PickBlockEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/event/PickBlockEvent.java
@@ -1,0 +1,11 @@
+package com.gtnewhorizon.gtnhlib.event;
+
+import cpw.mods.fml.common.eventhandler.Event;
+
+public class PickBlockEvent extends Event {
+
+    @Override
+    public boolean isCancelable() {
+        return true;
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -53,6 +53,7 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> GTNHLibConfig.enableTranslucentItemRenders)),
     MULTI_RELEASE_JAR_FILTER(new MixinBuilder("Skip multi-release JAR entries in mod discovery")
             .addCommonMixins("fml.MixinJarDiscoverer").setPhase(Phase.EARLY).addExcludedMod(TargetMods.LWJGL3IFY)),
+    PICK_BLOCK_TRAP(Side.CLIENT, "MixinMinecraft_PickBlockTrap"),
     //
     ;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinMinecraft_PickBlockTrap.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinMinecraft_PickBlockTrap.java
@@ -1,0 +1,22 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.common.MinecraftForge;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizon.gtnhlib.event.PickBlockEvent;
+
+@Mixin(Minecraft.class)
+public class MixinMinecraft_PickBlockTrap {
+
+    @Inject(method = "func_147112_ai", at = @At("HEAD"), cancellable = true)
+    private void gt5u$before$pickBlock(CallbackInfo ci) {
+        if (MinecraftForge.EVENT_BUS.post(new PickBlockEvent())) {
+            ci.cancel();
+        }
+    }
+}


### PR DESCRIPTION
This mixin posts a `PickBlockEvent` to the Minecraft Forge event bus, which can be canceled to prevent the default pick block behavior. The mixin applies itself at a level in the call stack that will not interfere with the hodgepodge mixin that makes the actual vanilla pick block mechanic more like modern Minecraft.

This was originally intended for use in GT5-Unofficial, but there was interest for use outside of that repository, so I'd like to add it here.