### PR TITLE
remap readFromNBT/writeToNBT injections in TileInFusionMatrix mixin

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/MixinEnhancedInfusionRecipe.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/MixinEnhancedInfusionRecipe.java
@@ -54,7 +54,8 @@ public abstract class MixinEnhancedInfusionRecipe extends TileThaumcraft {
             at = @At(
                     value = "INVOKE",
                     target = "Lthaumcraft/common/tiles/TilePedestal;getStackInSlot(I)Lnet/minecraft/item/ItemStack;",
-                    ordinal = 4))
+                    ordinal = 4,
+                    remap = true))
     public void itemReplacement(CallbackInfo ci, @Local TileEntity te, @Local int slot) {
         if (this.gTNHLib$replacements.isEmpty()) {
             return;


### PR DESCRIPTION
the injected methods are present in the target class, but they aren't used because there's no `writeToNBT` and `readFromNBT` methods in this class
<img width="910" height="218" alt="image" src="https://github.com/user-attachments/assets/973c42b8-3a5c-4d25-9ca6-ce95f3f9b5d4" />

they are `func_145841_b` and `func_145839_a` respectively because they are overridden MC TileEntity methods which are obfuscated

to fix the issue we need to remap the injections into `writeToNBT` and `readFromNBT`

fixes #270 not working in non-dev env