### PR TITLE
Add a method to automaticall make and register an EIR

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/thaumcraft/EnhancedInfusionRecipe.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/thaumcraft/EnhancedInfusionRecipe.java
@@ -37,7 +37,9 @@ public class EnhancedInfusionRecipe extends InfusionRecipe {
     }
 
     /**
-     * Automatically create and register an Enhanced Infusion Recipe, which is then returned for use, for example in a research page
+     * Automatically create and register an Enhanced Infusion Recipe, which is then returned for use, such as in a
+     * research page
+     *
      * @param research     The required research for this infusion
      * @param output       The item created by this infusion
      * @param inst         The instability of this infusion
@@ -45,19 +47,26 @@ public class EnhancedInfusionRecipe extends InfusionRecipe {
      * @param input        The item required to be placed on the central pedestal
      * @param recipe       The items required to be placed on the outer pedestals
      * @param replacements What items to replace consumed items with on the outer pedestals
-     * @return             The Enhanced infusion recipe created
+     * @return The Enhanced infusion recipe created
      */
 
-    public static EnhancedInfusionRecipe addEnhancedInfusionCraftingRecipe (String research, Object output, int inst, AspectList aspects2, ItemStack input, ItemStack[] recipe, List<Replacement> replacements) {
-        if(!(output instanceof ItemStack) && !(output instanceof Object[])) {
+    public static EnhancedInfusionRecipe addEnhancedInfusionCraftingRecipe(String research, Object output, int inst,
+            AspectList aspects2, ItemStack input, ItemStack[] recipe, List<Replacement> replacements) {
+        if (!(output instanceof ItemStack) && !(output instanceof Object[])) {
             return null;
         } else {
-            EnhancedInfusionRecipe r = new EnhancedInfusionRecipe(research, output, inst, aspects2, input, recipe, replacements);
+            EnhancedInfusionRecipe r = new EnhancedInfusionRecipe(
+                    research,
+                    output,
+                    inst,
+                    aspects2,
+                    input,
+                    recipe,
+                    replacements);
             ThaumcraftApi.getCraftingRecipes().add(r);
             return r;
         }
     }
-
 
     public List<Replacement> getReplacements() {
         return this.replacements;
@@ -66,8 +75,8 @@ public class EnhancedInfusionRecipe extends InfusionRecipe {
     /**
      * A Replacement defines one type of ItemStack (e.g. all Iron Ingots) to replace with another ItemStack (e.g.
      * Diamonds). Setting strict to false allows input to match with all metadata if input is given metadata of
-     * Short.MAX_VALUE. NBT data (such as enchantments) is ignored when comparing against input. The output may be null (e.g.
-     * for water buckets and other containers)
+     * Short.MAX_VALUE. NBT data (such as enchantments) is ignored when comparing against input. The output may be null
+     * (e.g. for water buckets and other containers)
      *
      * @param input  The input ItemStack to compare recipe ingredients against
      * @param output The ItemStack to replace items that match the input


### PR DESCRIPTION
Really should think of this earlier

Its a direct parallel to a method in THaumcraft api, which automatically makes and registers an infusion recipe, and then returns it for use in, for example, adding recipes to research pages, such as 

```
RingResearch.recipeList.put(
            "RBMastersRingOfAer",
            ThaumcraftApi.addInfusionCraftingRecipe(
                "RBMASTERSRINGOFAER",
                new ItemStack(BaubleItems.aerRing, 1, 2),
                5,
                (new AspectList()).add(Aspect.AIR, 64)
                    .add(Aspect.MAGIC, 64)
                    .add(Aspect.AURA, 48)
                    .add(Aspect.ENERGY, 32),
                new ItemStack(BaubleItems.aerRing, 1, 1),
                new ItemStack[] { new ItemStack(ConfigItems.itemEldritchObject, 1, 3),
                    new ItemStack(ConfigBlocks.blockCrystal, 1, 0), salisMundus,
                    new ItemStack(ConfigBlocks.blockCrystal, 1, 0), salisMundus,
                    new ItemStack(ConfigBlocks.blockCrystal, 1, 6), salisMundus,
                    new ItemStack(ConfigBlocks.blockCrystal, 1, 0), salisMundus,
                    new ItemStack(ConfigBlocks.blockCrystal, 1, 0) }));
```
(im working on swapping randombaubles to EIR so there's less jank for the pearl return, hence using code excerpt from there)