### PR TITLE
Add gui keybind fallback check

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/keybind/SyncedKeybind.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/keybind/SyncedKeybind.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 
 import org.lwjgl.input.Keyboard;
+import org.lwjgl.input.Mouse;
 
 import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
 import com.gtnewhorizon.gtnhlib.network.NetworkHandler;
@@ -121,7 +122,9 @@ public final class SyncedKeybind {
         if (player.worldObj.isRemote) {
             if (keybinding != null) {
                 // fallback on the client when in a gui
-                return keybinding.getIsKeyPressed() || Keyboard.isKeyDown(keybinding.getKeyCode());
+                return keybinding.getIsKeyPressed()
+                        || (keybinding.getKeyCode() < 0 ? Mouse.isButtonDown(keybinding.getKeyCode() + 100)
+                                : Keyboard.isKeyDown(keybinding.getKeyCode()));
             }
             return Keyboard.isKeyDown(keyCode);
         }


### PR DESCRIPTION
When SyncedKeybind#isKeyDown is called from a gui, they always return false since they have not been ticked.

Fixes https://github.com/GTNewHorizons/GTNHLib/issues/237