### PR TITLE
Fix EIr only passing the replacements once per world restart

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/thaumcraft/EnhancedInfusionRecipe.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/thaumcraft/EnhancedInfusionRecipe.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizon.gtnhlib.api.thaumcraft;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.item.ItemStack;
@@ -69,7 +70,7 @@ public class EnhancedInfusionRecipe extends InfusionRecipe {
     }
 
     public List<Replacement> getReplacements() {
-        return this.replacements;
+        return new ArrayList<>(this.replacements);
     }
 
     /**


### PR DESCRIPTION
Fix the Enhanced infusion recipe only passing the replacement list to the mixin once, as its the actual list and not a copy, and so the clear at the end of the infusion matrix run is probably deleting it. 

~~Am too tired to test, will undraft when i do tomorrow.~~

Fix looks to have worked. Could not do more than one before a restart on this instance, with the fix I can. 
<img width="128" height="89" alt="image" src="https://github.com/user-attachments/assets/2040b11f-21a2-46b6-aef2-daefdafafc29" />
