### PR TITLE
Move StdLCG to GTNHLib

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/StdLCG.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/StdLCG.java
@@ -11,6 +11,8 @@ public class StdLCG extends Random {
     protected static final long multiplier = 0x5DEECE66DL;
     protected static final long increment = 11;
     protected long seed;
+    protected boolean haveNextNextGaussian = false;
+    protected double nextNextGaussian = 0.0;
 
     /// Don't ask me why stdlib scrambles the seed, because I don't know.
     public StdLCG(long seed) {
@@ -26,25 +28,38 @@ public class StdLCG extends Random {
         return (seed ^ multiplier) & mask;
     }
 
-    /// To conform to stdlib, this still makes a super call. That means this is synchronized, and should be avoided
-    /// unless you *really* need to reset {@link Random#haveNextNextGaussian}.
     @Override
     public void setSeed(long seed) {
-        super.setSeed(seed);
         this.seed = scramble(seed);
-    }
-
-    /// Unlike {@link #setSeed(long)}, this doesn't reset {@link Random#haveNextNextGaussian}, because that field is
-    /// private. Use this method if you don't care about the {@link #nextGaussian()} methods and want to avoid
-    /// synchronizing on seed setting.
-    public StdLCG setSeedLCG(long seed) {
-        this.seed = scramble(seed);
-        return this;
+        haveNextNextGaussian = false;
     }
 
     @Override
     protected int next(int bits) {
         seed = (seed * multiplier + increment) & mask;
         return (int) (seed >>> 48 - bits);
+    }
+
+    /// A reimplementation of Knuth's algorithm, except I read the 2nd edition instead of the 3rd. It's probably close
+    /// enough.
+    @Override
+    public double nextGaussian() {
+        if (haveNextNextGaussian) {
+            haveNextNextGaussian = false;
+            return nextNextGaussian;
+        }
+
+        double s, v1, v2;
+        do {
+            v1 = 2 * nextDouble() - 1;
+            v2 = 2 * nextDouble() - 1;
+            s = v1 * v1 + v2 * v2;
+            // Knuth doesn't say to return if s==0, but stdlib does. We need to match stdlib, so another clause it is.
+        } while (s >= 1 || s == 0);
+
+        final var tmpRoot = StrictMath.sqrt(-2 * StrictMath.log(s) / s);
+        nextNextGaussian = v2 * tmpRoot;
+        haveNextNextGaussian = true;
+        return v1 * tmpRoot;
     }
 }

--- a/src/test/java/com/gtnewhorizon/gtnhlib/test/util/StdLCGTest.java
+++ b/src/test/java/com/gtnewhorizon/gtnhlib/test/util/StdLCGTest.java
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Test;
 
 import com.gtnewhorizon.gtnhlib.util.StdLCG;
 
+/// Ensures {@link StdLCG} matches {@link Random}'s output in a variety of scenarios.
 public class StdLCGTest {
 
-    /// Ensures {@link StdLCG} matches {@link Random}'s output in a variety of scenarios.
     @Test
-    void testStdlibConformance() {
+    void testNextLongConformance() {
         // ...after construction,
         final var stdlib = new Random(900);
         final var lcg = new StdLCG(900);
@@ -20,18 +20,28 @@ public class StdLCGTest {
         assertEquals(stdlib.nextLong(), lcg.nextLong());
         assertEquals(stdlib.nextLong(), lcg.nextLong());
 
-        // ...after post-construction seeding,
+        // ...and after post-construction seeding
         stdlib.setSeed(9425125);
         lcg.setSeed(9425125);
         assertEquals(stdlib.nextLong(), lcg.nextLong());
         assertEquals(stdlib.nextLong(), lcg.nextLong());
         assertEquals(stdlib.nextLong(), lcg.nextLong());
+    }
 
-        // ...and using the non-stdlib seeding method.
-        stdlib.setSeed(8502258);
-        lcg.setSeedLCG(8502258);
-        assertEquals(stdlib.nextLong(), lcg.nextLong());
-        assertEquals(stdlib.nextLong(), lcg.nextLong());
-        assertEquals(stdlib.nextLong(), lcg.nextLong());
+    @Test
+    void testNextGaussianConformance() {
+        // ...after construction,
+        final var stdlib = new Random(900);
+        final var lcg = new StdLCG(900);
+        assertEquals(stdlib.nextGaussian(), lcg.nextGaussian());
+        assertEquals(stdlib.nextGaussian(), lcg.nextGaussian());
+        assertEquals(stdlib.nextGaussian(), lcg.nextGaussian());
+
+        // ...and after post-construction seeding
+        stdlib.setSeed(9425125);
+        lcg.setSeed(9425125);
+        assertEquals(stdlib.nextGaussian(), lcg.nextGaussian());
+        assertEquals(stdlib.nextGaussian(), lcg.nextGaussian());
+        assertEquals(stdlib.nextGaussian(), lcg.nextGaussian());
     }
 }


### PR DESCRIPTION
Originally added to Hodgepodge, but likely useful in other mods too. As such, I'm moving it to GTNHLib. This PR doesn't remove it from Hodgepodge, that can be done later.

This is also slightly different from the original, in that it now should behave identically to stdlib after seeding. I never tested the old one, but I don't think it did.