### PR TITLE
Set colorIdx to -1 default

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/cel/model/quad/ModelQuad.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/cel/model/quad/ModelQuad.java
@@ -30,7 +30,7 @@ public class ModelQuad implements ModelQuadViewMutable {
     private int normal;
 
     private Object sprite;
-    private int colorIdx;
+    private int colorIdx = -1;
     private boolean transparent = false;
     private ModelQuadFacing direction;
 


### PR DESCRIPTION
Every place that references `colorIdx` appears to check if it's -1 as some default. This includes:
- `ModelQuadView#hasColor` (returns true if colorIdx != -1).
- `ModelISBRH`, where if the index is != -1 it gets the color for a quad from an underlying BlockColor, and if it is == -1, just uses the model's single color.

So, this PR sets the default in `ModelQuad` to be -1.