### PR TITLE
Minor configuration system cleanup

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigException.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigException.java
@@ -3,7 +3,7 @@ package com.gtnewhorizon.gtnhlib.config;
 /**
  * A really basic wrapper for config to simplify handling them in external code.
  */
-public class ConfigException extends Exception {
+public class ConfigException extends RuntimeException {
 
     public ConfigException(String message) {
         super(message);

--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigFieldParser.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigFieldParser.java
@@ -596,13 +596,13 @@ public class ConfigFieldParser {
         @Override
         @SneakyThrows
         public void setFromString(@Nullable Object instance, String value, Field field) {
-            field.set(instance, value.split("|||"));
+            field.set(instance, value.split("\n"));
         }
 
         @Override
         @SneakyThrows
         public String getAsString(@Nullable Object instance, Field field) {
-            return String.join("|||", (String[]) field.get(instance));
+            return String.join("\n", (String[]) field.get(instance));
         }
     }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigFieldParser.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigFieldParser.java
@@ -18,7 +18,6 @@ import cpw.mods.fml.common.Loader;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import lombok.SneakyThrows;
-import lombok.val;
 
 public class ConfigFieldParser {
 
@@ -47,8 +46,8 @@ public class ConfigFieldParser {
             Parser parser = getParser(field);
             var comment = Optional.ofNullable(field.getAnnotation(Config.Comment.class)).map(Config.Comment::value)
                     .map((lines) -> String.join("\n", lines)).orElse("");
-            val name = getFieldName(field);
-            val defValueString = getModDefault(field);
+            final var name = getFieldName(field);
+            final var defValueString = getModDefault(field);
             parser.load(instance, defValueString, field, config, category, name, comment, key);
         } catch (Exception e) {
             throw new ConfigException(
@@ -65,7 +64,7 @@ public class ConfigFieldParser {
     public static void saveField(Object instance, Field field, Configuration config, String category)
             throws ConfigException {
         try {
-            val name = getFieldName(field);
+            final var name = getFieldName(field);
             Parser parser = getParser(field);
             parser.save(instance, field, config, category, name);
         } catch (Exception e) {
@@ -108,7 +107,7 @@ public class ConfigFieldParser {
     }
 
     private static @Nullable String getModDefault(Field field) {
-        val modDefaultList = field.getAnnotation(Config.ModDetectedDefaultList.class);
+        final var modDefaultList = field.getAnnotation(Config.ModDetectedDefaultList.class);
         if (modDefaultList != null) {
             return Arrays.stream(modDefaultList.values()).filter(ConfigFieldParser::isModDetected).findFirst()
                     .map(
@@ -117,7 +116,7 @@ public class ConfigFieldParser {
                     .orElse(null);
         }
 
-        val modDefault = field.getAnnotation(Config.ModDetectedDefault.class);
+        final var modDefault = field.getAnnotation(Config.ModDetectedDefault.class);
         if (isModDetected(modDefault)) {
             return modDefault.values().length != 0 ? String.join(",", modDefault.values()) : modDefault.value().trim();
         }
@@ -127,8 +126,8 @@ public class ConfigFieldParser {
 
     private static boolean isModDetected(Config.ModDetectedDefault modDefault) {
         if (modDefault == null) return false;
-        val modID = modDefault.modID();
-        val coremod = modDefault.coremod();
+        final var modID = modDefault.modID();
+        final var coremod = modDefault.coremod();
         if (modID.isEmpty() && coremod.isEmpty()) return false;
         return detectedMods.computeIfAbsent(modID.isEmpty() ? coremod : modID, id -> {
             if (!coremod.isEmpty()) {
@@ -144,7 +143,7 @@ public class ConfigFieldParser {
 
     static String getValueAsString(@Nullable Object instance, Field field) throws ConfigException {
         try {
-            val parser = getParser(field);
+            final var parser = getParser(field);
             return parser.getAsString(instance, field);
         } catch (Exception e) {
             throw new ConfigException(
@@ -160,7 +159,7 @@ public class ConfigFieldParser {
 
     static void setValueFromString(@Nullable Object instance, Field field, String value) throws ConfigException {
         try {
-            val parser = getParser(field);
+            final var parser = getParser(field);
             parser.setFromString(instance, value, field);
         } catch (Exception e) {
             throw new ConfigException(
@@ -203,7 +202,7 @@ public class ConfigFieldParser {
         @SneakyThrows
         public void load(@Nullable Object instance, @Nullable String defValueString, Field field, Configuration config,
                 String category, String name, String comment, String langKey) {
-            val defaultValue = fromStringOrDefault(instance, defValueString, field);
+            final var defaultValue = fromStringOrDefault(instance, defValueString, field);
             field.setBoolean(instance, config.getBoolean(name, category, defaultValue, comment, langKey));
         }
 
@@ -217,7 +216,7 @@ public class ConfigFieldParser {
 
         @SneakyThrows
         private boolean fromStringOrDefault(@Nullable Object instance, @Nullable String defValueString, Field field) {
-            val boxed = field.getType().equals(Boolean.class);
+            final var boxed = field.getType().equals(Boolean.class);
             if (defValueString == null) {
                 return Optional.ofNullable(field.getAnnotation(Config.DefaultBoolean.class))
                         .map(Config.DefaultBoolean::value)
@@ -235,7 +234,7 @@ public class ConfigFieldParser {
         @Override
         @SneakyThrows
         public void setFromString(@Nullable Object instance, String value, Field field) {
-            val boxed = field.getType().equals(Boolean.class);
+            final var boxed = field.getType().equals(Boolean.class);
             if (boxed) {
                 field.set(instance, Boolean.parseBoolean(value));
                 return;
@@ -247,7 +246,7 @@ public class ConfigFieldParser {
         @Override
         @SneakyThrows
         public String getAsString(@Nullable Object instance, Field field) {
-            val boxed = field.getType().equals(Boolean.class);
+            final var boxed = field.getType().equals(Boolean.class);
             return Boolean.toString(boxed ? (Boolean) field.get(instance) : field.getBoolean(instance));
         }
     }
@@ -258,10 +257,10 @@ public class ConfigFieldParser {
         @SneakyThrows
         public void load(@Nullable Object instance, @Nullable String defValueString, Field field, Configuration config,
                 String category, String name, String comment, String langKey) {
-            val range = Optional.ofNullable(field.getAnnotation(Config.RangeInt.class));
-            val min = range.map(Config.RangeInt::min).orElse(Integer.MIN_VALUE);
-            val max = range.map(Config.RangeInt::max).orElse(Integer.MAX_VALUE);
-            val defaultValue = fromStringOrDefault(instance, defValueString, field);
+            final var range = Optional.ofNullable(field.getAnnotation(Config.RangeInt.class));
+            final var min = range.map(Config.RangeInt::min).orElse(Integer.MIN_VALUE);
+            final var max = range.map(Config.RangeInt::max).orElse(Integer.MAX_VALUE);
+            final var defaultValue = fromStringOrDefault(instance, defValueString, field);
 
             field.setInt(instance, config.getInt(name, category, defaultValue, min, max, comment, langKey));
         }
@@ -276,7 +275,7 @@ public class ConfigFieldParser {
 
         @SneakyThrows
         private int fromStringOrDefault(@Nullable Object instance, @Nullable String defValueString, Field field) {
-            val boxed = field.getType().equals(Integer.class);
+            final var boxed = field.getType().equals(Integer.class);
             if (defValueString == null) {
                 return Optional.ofNullable(field.getAnnotation(Config.DefaultInt.class)).map(Config.DefaultInt::value)
                         .orElse(boxed ? (Integer) field.get(instance) : field.getInt(instance));
@@ -288,7 +287,7 @@ public class ConfigFieldParser {
         @Override
         @SneakyThrows
         public void setFromString(@Nullable Object instance, String value, Field field) {
-            val boxed = field.getType().equals(Integer.class);
+            final var boxed = field.getType().equals(Integer.class);
             if (boxed) {
                 field.set(instance, Integer.parseInt(value));
                 return;
@@ -300,7 +299,7 @@ public class ConfigFieldParser {
         @Override
         @SneakyThrows
         public String getAsString(@Nullable Object instance, Field field) {
-            val boxed = field.getType().equals(Integer.class);
+            final var boxed = field.getType().equals(Integer.class);
             return Integer.toString(boxed ? (Integer) field.get(instance) : field.getInt(instance));
         }
     }
@@ -311,10 +310,10 @@ public class ConfigFieldParser {
         @SneakyThrows
         public void load(@Nullable Object instance, @Nullable String defValueString, Field field, Configuration config,
                 String category, String name, String comment, String langKey) {
-            val range = Optional.ofNullable(field.getAnnotation(Config.RangeFloat.class));
-            val min = range.map(Config.RangeFloat::min).orElse(Float.MIN_VALUE);
-            val max = range.map(Config.RangeFloat::max).orElse(Float.MAX_VALUE);
-            val defaultValue = fromStringOrDefault(instance, defValueString, field);
+            final var range = Optional.ofNullable(field.getAnnotation(Config.RangeFloat.class));
+            final var min = range.map(Config.RangeFloat::min).orElse(Float.MIN_VALUE);
+            final var max = range.map(Config.RangeFloat::max).orElse(Float.MAX_VALUE);
+            final var defaultValue = fromStringOrDefault(instance, defValueString, field);
             field.setFloat(instance, config.getFloat(name, category, defaultValue, min, max, comment, langKey));
         }
 
@@ -328,7 +327,7 @@ public class ConfigFieldParser {
 
         @SneakyThrows
         private float fromStringOrDefault(@Nullable Object instance, @Nullable String defValueString, Field field) {
-            val boxed = field.getType().equals(Float.class);
+            final var boxed = field.getType().equals(Float.class);
             if (defValueString == null) {
                 return Optional.ofNullable(field.getAnnotation(Config.DefaultFloat.class))
                         .map(Config.DefaultFloat::value)
@@ -341,7 +340,7 @@ public class ConfigFieldParser {
         @Override
         @SneakyThrows
         public void setFromString(@org.jetbrains.annotations.Nullable Object instance, String value, Field field) {
-            val boxed = field.getType().equals(Float.class);
+            final var boxed = field.getType().equals(Float.class);
             if (boxed) {
                 field.set(instance, Float.parseFloat(value));
                 return;
@@ -353,7 +352,7 @@ public class ConfigFieldParser {
         @Override
         @SneakyThrows
         public String getAsString(@Nullable Object instance, Field field) {
-            val boxed = field.getType().equals(Float.class);
+            final var boxed = field.getType().equals(Float.class);
             return Float.toString(boxed ? (Float) field.get(instance) : field.getFloat(instance));
         }
     }
@@ -364,12 +363,18 @@ public class ConfigFieldParser {
         @SneakyThrows
         public void load(@Nullable Object instance, @Nullable String defValueString, Field field, Configuration config,
                 String category, String name, String comment, String langKey) {
-            val range = Optional.ofNullable(field.getAnnotation(Config.RangeDouble.class));
-            val min = range.map(Config.RangeDouble::min).orElse(Double.MIN_VALUE);
-            val max = range.map(Config.RangeDouble::max).orElse(Double.MAX_VALUE);
-            val defaultValue = fromStringOrDefault(instance, defValueString, field);
+            final var range = Optional.ofNullable(field.getAnnotation(Config.RangeDouble.class));
+            final var min = range.map(Config.RangeDouble::min).orElse(Double.MIN_VALUE);
+            final var max = range.map(Config.RangeDouble::max).orElse(Double.MAX_VALUE);
+            final var defaultValue = fromStringOrDefault(instance, defValueString, field);
 
-            val defaultValueComment = comment + " [range: " + min + " ~ " + max + ", default: " + defaultValue + "]";
+            final var defaultValueComment = comment + " [range: "
+                    + min
+                    + " ~ "
+                    + max
+                    + ", default: "
+                    + defaultValue
+                    + "]";
             field.setDouble(
                     instance,
                     config.get(category, name, defaultValue, defaultValueComment, min, max).setLanguageKey(langKey)
@@ -386,7 +391,7 @@ public class ConfigFieldParser {
 
         @SneakyThrows
         private double fromStringOrDefault(@Nullable Object instance, @Nullable String defValueString, Field field) {
-            val boxed = field.getType().equals(Double.class);
+            final var boxed = field.getType().equals(Double.class);
             if (defValueString == null) {
                 return Optional.ofNullable(field.getAnnotation(Config.DefaultDouble.class))
                         .map(Config.DefaultDouble::value)
@@ -399,7 +404,7 @@ public class ConfigFieldParser {
         @Override
         @SneakyThrows
         public void setFromString(@Nullable Object instance, String value, Field field) {
-            val boxed = field.getType().equals(Double.class);
+            final var boxed = field.getType().equals(Double.class);
             if (boxed) {
                 field.set(instance, Double.parseDouble(value));
                 return;
@@ -411,7 +416,7 @@ public class ConfigFieldParser {
         @Override
         @SneakyThrows
         public String getAsString(@Nullable Object instance, Field field) {
-            val boxed = field.getType().equals(Double.class);
+            final var boxed = field.getType().equals(Double.class);
             return Double.toString(boxed ? (Double) field.get(instance) : field.getDouble(instance));
         }
     }
@@ -422,9 +427,9 @@ public class ConfigFieldParser {
         @SneakyThrows
         public void load(@Nullable Object instance, @Nullable String defValueString, Field field, Configuration config,
                 String category, String name, String comment, String langKey) {
-            val defaultValue = fromStringOrDefault(instance, defValueString, field);
-            val pattern = Optional.ofNullable(field.getAnnotation(Config.Pattern.class)).map(Config.Pattern::value)
-                    .map(Pattern::compile).orElse(null);
+            final var defaultValue = fromStringOrDefault(instance, defValueString, field);
+            final var pattern = Optional.ofNullable(field.getAnnotation(Config.Pattern.class))
+                    .map(Config.Pattern::value).map(Pattern::compile).orElse(null);
             field.set(instance, config.getString(name, category, defaultValue, comment, langKey, pattern));
         }
 
@@ -465,10 +470,10 @@ public class ConfigFieldParser {
         public void load(@Nullable Object instance, @Nullable String defValueString, Field field, Configuration config,
                 String category, String name, String comment, String langKey) {
             Class<?> fieldClass = field.getType();
-            val enumValues = Arrays.stream((Object[]) fieldClass.getDeclaredMethod("values").invoke(instance))
+            final var enumValues = Arrays.stream((Object[]) fieldClass.getDeclaredMethod("values").invoke(instance))
                     .map((obj) -> (Enum<?>) obj).collect(Collectors.toList());
-            val defaultValue = fromStringOrDefault(instance, defValueString, field, enumValues);
-            val possibleValues = enumValues.stream().map(Enum::name).toArray(String[]::new);
+            final var defaultValue = fromStringOrDefault(instance, defValueString, field, enumValues);
+            final var possibleValues = enumValues.stream().map(Enum::name).toArray(String[]::new);
             String value = config.getString(
                     name,
                     category,
@@ -521,7 +526,7 @@ public class ConfigFieldParser {
                         .map(Config.DefaultEnum::value).map((defName) -> extractField(field.getType(), defName))
                         .map(ConfigFieldParser::extractValue).orElse(field.get(instance));
             } else {
-                val modDefaultField = extractField(field.getType(), defValueString);
+                final var modDefaultField = extractField(field.getType(), defValueString);
                 value = (Enum<?>) extractValue(modDefaultField);
             }
 
@@ -564,15 +569,15 @@ public class ConfigFieldParser {
         @SneakyThrows
         public void load(@Nullable Object instance, @Nullable String defValueString, Field field, Configuration config,
                 String category, String name, String comment, String langKey) {
-            val defaultValue = fromStringOrDefault(instance, defValueString, field);
-            val value = config.getStringList(name, category, defaultValue, comment, null, langKey);
+            final var defaultValue = fromStringOrDefault(instance, defValueString, field);
+            final var value = config.getStringList(name, category, defaultValue, comment, null, langKey);
             field.set(instance, value);
         }
 
         @Override
         @SneakyThrows
         public void save(@Nullable Object instance, Field field, Configuration config, String category, String name) {
-            val prop = config.getCategory(category).get(name);
+            final var prop = config.getCategory(category).get(name);
             prop.set((String[]) field.get(instance));
         }
 
@@ -607,7 +612,7 @@ public class ConfigFieldParser {
         @SneakyThrows
         public void load(@Nullable Object instance, @Nullable String defValueString, Field field, Configuration config,
                 String category, String name, String comment, String langKey) {
-            val defaultValue = fromStringOrDefault(instance, defValueString, field);
+            final var defaultValue = fromStringOrDefault(instance, defValueString, field);
 
             String[] stringValues = new String[defaultValue.length];
             for (int i = 0; i < defaultValue.length; i++) {
@@ -660,7 +665,7 @@ public class ConfigFieldParser {
         @SneakyThrows
         public void load(@Nullable Object instance, @Nullable String defValueString, Field field, Configuration config,
                 String category, String name, String comment, String langKey) {
-            val defaultValue = fromStringOrDefault(instance, defValueString, field);
+            final var defaultValue = fromStringOrDefault(instance, defValueString, field);
             String[] stringValues = new String[defaultValue.length];
             for (int i = 0; i < defaultValue.length; i++) {
                 stringValues[i] = Integer.toString(defaultValue[i]);

--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
@@ -47,14 +47,13 @@ public class ConfigurationManager {
     private static final Map<Configuration, Map<String, Set<Class<?>>>> configToCategoryClassMap = new HashMap<>();
     private static final Map<String, Set<Class<?>>> modIdToConfigClasses = new HashMap<>();
     private static final String[] langKeyPlaceholders = new String[] { "%mod", "%file", "%cat", "%field" };
-    private static final Boolean PRINT_KEYS = Boolean.getBoolean("gtnhlib.printkeys");
-    private static final Boolean DUMP_KEYS = Boolean.getBoolean("gtnhlib.dumpkeys");
+    private static final boolean PRINT_KEYS = Boolean.getBoolean("gtnhlib.printkeys");
+    private static final boolean DUMP_KEYS = Boolean.getBoolean("gtnhlib.dumpkeys");
     private static final Map<String, List<String>> generatedLangKeys = new HashMap<>();
     private static final Map<Configuration, Set<String>> observedCategories = new HashMap<>();
     private static final Map<ConfigCategory, Class<?>> configEntries = new HashMap<>();
     private static final Map<Class<?>, ConfigNode> configNode = new HashMap<>();
 
-    private static final ConfigurationManager instance = new ConfigurationManager();
     private final static Path configDir;
 
     static {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
@@ -261,7 +261,7 @@ public class ConfigurationManager {
 
         if (category.isEmpty()) return;
 
-        if (cat.keySet().size() != observedValues.size()) {
+        if (cat.size() != observedValues.size()) {
             final var properties = new ArrayList<>(cat.keySet());
             properties.removeIf(observedValues::contains);
             properties.forEach(cat::remove);
@@ -619,7 +619,7 @@ public class ConfigurationManager {
                 }
                 String fieldName = ConfigFieldParser.getFieldName(field).toLowerCase();
                 Config.Order ann = field.getAnnotation(Config.Order.class);
-                if (ann != null && fieldName != null) fieldOrder.put(fieldName, ann.value());
+                if (ann != null) fieldOrder.put(fieldName, ann.value());
                 if (ConfigurationManager.isFieldSubCategory(field)) {
                     children.put(fieldName, new ConfigNode(field.getType()));
                 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/config/ConfigurationManager.java
@@ -31,15 +31,10 @@ import org.jetbrains.annotations.NotNull;
 
 import cpw.mods.fml.client.config.IConfigElement;
 import cpw.mods.fml.common.FMLCommonHandler;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.val;
 
 /**
  * Class for controlling the loading of configuration files.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-@SuppressWarnings("unused")
 public class ConfigurationManager {
 
     static final Logger LOGGER = LogManager.getLogger("GTNHLibConfig");
@@ -60,17 +55,19 @@ public class ConfigurationManager {
         configDir = minecraftHome().toPath().resolve("config");
     }
 
+    private ConfigurationManager() {}
+
     /**
      * Registers a configuration class to be loaded. This should be done before or during preInit.
      *
      * @param configClass The class to register.
      */
     public static void registerConfig(Class<?> configClass) throws ConfigException {
-        val cfg = Optional.ofNullable(configClass.getAnnotation(Config.class)).orElseThrow(
+        final var cfg = Optional.ofNullable(configClass.getAnnotation(Config.class)).orElseThrow(
                 () -> new ConfigException("Class " + configClass.getName() + " does not have a @Config annotation!"));
-        val category = cfg.category().trim().toLowerCase();
-        val modid = cfg.modid();
-        val filename = Optional.of(cfg.filename().trim()).filter(s -> !s.isEmpty()).orElse(modid);
+        final var category = cfg.category().trim().toLowerCase();
+        final var modid = cfg.modid();
+        final var filename = Optional.of(cfg.filename().trim()).filter(s -> !s.isEmpty()).orElse(modid);
 
         if (!configClass.isAnnotationPresent(Config.ExcludeFromAutoGui.class)) {
             modIdToConfigClasses.computeIfAbsent(modid, (ignored) -> new HashSet<>()).add(configClass);
@@ -81,8 +78,8 @@ public class ConfigurationManager {
             if (!cfg.configSubDirectory().trim().isEmpty()) {
                 newConfigDir = newConfigDir.resolve(cfg.configSubDirectory().trim());
             }
-            val configFile = newConfigDir.resolve(filename + ".cfg").toFile();
-            val config = new Configuration(configFile);
+            final var configFile = newConfigDir.resolve(filename + ".cfg").toFile();
+            final var config = new Configuration(configFile);
             config.load();
             return config;
         });
@@ -104,11 +101,11 @@ public class ConfigurationManager {
         if (configClasses.length == 0) return;
 
         Set<Configuration> savedConfigs = new HashSet<>();
-        for (val clazz : configClasses) {
+        for (final var clazz : configClasses) {
             try {
-                val cfg = Optional.ofNullable(clazz.getAnnotation(Config.class)).orElseThrow(
+                final var cfg = Optional.ofNullable(clazz.getAnnotation(Config.class)).orElseThrow(
                         () -> new ConfigException("Class " + clazz.getName() + " does not have a @Config annotation!"));
-                val category = cfg.category().trim().toLowerCase();
+                final var category = cfg.category().trim().toLowerCase();
                 Configuration rawConfig = configs.get(getConfigKey(cfg));
                 save(clazz, null, rawConfig, category);
                 savedConfigs.add(rawConfig);
@@ -122,7 +119,7 @@ public class ConfigurationManager {
 
     private static void save(Class<?> configClass, Object instance, Configuration rawConfig, String category)
             throws IllegalAccessException, ConfigException {
-        for (val field : configClass.getDeclaredFields()) {
+        for (final var field : configClass.getDeclaredFields()) {
             if (shouldSkipField(field)) {
                 continue;
             }
@@ -136,7 +133,7 @@ public class ConfigurationManager {
 
             if (!ConfigFieldParser.canParse(field)) {
                 if (isFieldSubCategory(field)) {
-                    val cat = (category.isEmpty() ? "" : category + Configuration.CATEGORY_SPLITTER)
+                    final var cat = (category.isEmpty() ? "" : category + Configuration.CATEGORY_SPLITTER)
                             + ConfigFieldParser.getFieldName(field).toLowerCase();
                     Object subInstance = field.get(instance);
                     save(field.getType(), subInstance, rawConfig, cat);
@@ -152,8 +149,8 @@ public class ConfigurationManager {
 
     private static void processSubCategory(Object instance, Configuration config, Field subCategoryField,
             String category) throws ConfigException {
-        val name = ConfigFieldParser.getFieldName(subCategoryField);
-        val cat = (category.isEmpty() ? "" : category + Configuration.CATEGORY_SPLITTER) + name.toLowerCase();
+        final var name = ConfigFieldParser.getFieldName(subCategoryField);
+        final var cat = (category.isEmpty() ? "" : category + Configuration.CATEGORY_SPLITTER) + name.toLowerCase();
         ConfigCategory subCat = config.getCategory(cat);
 
         Optional.ofNullable(subCategoryField.getAnnotation(Config.Comment.class)).map(Config.Comment::value)
@@ -191,7 +188,7 @@ public class ConfigurationManager {
                 || foundCategory && cat.requiresWorldRestart();
 
         List<String> observedValues = new ArrayList<>();
-        for (val field : configClass.getDeclaredFields()) {
+        for (final var field : configClass.getDeclaredFields()) {
             if (shouldSkipField(field)) {
                 continue;
             }
@@ -224,8 +221,8 @@ public class ConfigurationManager {
 
             if (category.isEmpty()) continue;
 
-            val fieldName = ConfigFieldParser.getFieldName(field);
-            val langKey = getLangKey(configClass, field.getAnnotation(Config.LangKey.class), fieldName, cat);
+            final var fieldName = ConfigFieldParser.getFieldName(field);
+            final var langKey = getLangKey(configClass, field.getAnnotation(Config.LangKey.class), fieldName, cat);
             ConfigFieldParser.loadField(instance, field, rawConfig, category, langKey);
             observedValues.add(fieldName);
 
@@ -265,13 +262,13 @@ public class ConfigurationManager {
         if (category.isEmpty()) return;
 
         if (cat.keySet().size() != observedValues.size()) {
-            val properties = new ArrayList<>(cat.keySet());
+            final var properties = new ArrayList<>(cat.keySet());
             properties.removeIf(observedValues::contains);
             properties.forEach(cat::remove);
         }
 
         if (cat.getLanguagekey().equals(category)) {
-            val langKey = getLangKey(configClass, configClass.getAnnotation(Config.LangKey.class), null, cat);
+            final var langKey = getLangKey(configClass, configClass.getAnnotation(Config.LangKey.class), null, cat);
             cat.setLanguageKey(langKey);
         }
 
@@ -307,9 +304,9 @@ public class ConfigurationManager {
     @SuppressWarnings("rawtypes")
     public static List<IConfigElement> getConfigElements(Class<?> configClass, boolean categorized)
             throws ConfigException {
-        val cfg = Optional.ofNullable(configClass.getAnnotation(Config.class)).orElseThrow(
+        final var cfg = Optional.ofNullable(configClass.getAnnotation(Config.class)).orElseThrow(
                 () -> new ConfigException("Class " + configClass.getName() + " does not have a @Config annotation!"));
-        val rawConfig = Optional.ofNullable(configs.get(getConfigKey(cfg))).map(
+        final var rawConfig = Optional.ofNullable(configs.get(getConfigKey(cfg))).map(
                 (conf) -> Optional.ofNullable(configToCategoryClassMap.get(conf))
                         .map((map) -> map.get(cfg.category().trim().toLowerCase()).contains(configClass)).orElse(false)
                                 ? conf
@@ -317,7 +314,7 @@ public class ConfigurationManager {
                 .orElseThrow(
                         () -> new ConfigException("Tried to get config elements for non-registered config class!"));
 
-        val category = cfg.category().toLowerCase();
+        final var category = cfg.category().toLowerCase();
         List<IConfigElement> result = new ArrayList<>();
         if (categorized) {
             if (category.isEmpty()) return getSubcategoryElements(configClass, category, rawConfig, true);
@@ -329,7 +326,7 @@ public class ConfigurationManager {
                             rawConfig,
                             category));
         } else {
-            val elements = category.isEmpty() ? getSubcategoryElements(configClass, category, rawConfig, false)
+            final var elements = category.isEmpty() ? getSubcategoryElements(configClass, category, rawConfig, false)
                     : new ConfigElement<>(rawConfig.getCategory(category)).getChildElements();
             elements.stream().map((element) -> getProxyElement(element, configClass, rawConfig, category))
                     .forEach(result::add);
@@ -352,8 +349,8 @@ public class ConfigurationManager {
             case 1:
                 return getConfigElements(configClasses[0], categorized);
             default:
-                val result = new ArrayList<IConfigElement>();
-                for (val configClass : configClasses) {
+                final var result = new ArrayList<IConfigElement>();
+                for (final var configClass : configClasses) {
                     List<IConfigElement> elements = getConfigElements(configClass, categorized);
                     result.addAll(elements);
                 }
@@ -365,12 +362,12 @@ public class ConfigurationManager {
     private static List<IConfigElement> getSubcategoryElements(Class<?> configClass, String category,
             Configuration rawConfig, boolean categorized) {
         List<IConfigElement> elements = new ArrayList<>();
-        for (val field : configClass.getDeclaredFields()) {
+        for (final var field : configClass.getDeclaredFields()) {
             if (shouldSkipField(field)) {
                 continue;
             }
             if (isFieldSubCategory(field)) {
-                val name = ConfigFieldParser.getFieldName(field).toLowerCase();
+                final var name = ConfigFieldParser.getFieldName(field).toLowerCase();
                 elements.add(
                         getProxyElement(
                                 new ConfigElement(rawConfig.getCategory(name)),
@@ -493,7 +490,7 @@ public class ConfigurationManager {
     }
 
     public static Configuration getConfig(Class<?> configClass) {
-        val cfg = configClass.getAnnotation(Config.class);
+        final var cfg = configClass.getAnnotation(Config.class);
         return configs.get(getConfigKey(cfg));
     }
 
@@ -526,11 +523,11 @@ public class ConfigurationManager {
             ConfigCategory cat = entry.getKey();
             Class<?> configClass = entry.getValue();
 
-            for (val field : configClass.getDeclaredFields()) {
+            for (final var field : configClass.getDeclaredFields()) {
                 if (shouldSkipField(field)) {
                     continue;
                 }
-                val fieldName = ConfigFieldParser.getFieldName(field);
+                final var fieldName = ConfigFieldParser.getFieldName(field);
                 Config.Entry fieldEntry = field.getAnnotation(Config.Entry.class);
                 if (fieldEntry != null && fieldEntry.value() != null) {
                     if (cat.get(fieldName) != null) {
@@ -548,7 +545,7 @@ public class ConfigurationManager {
 
     private static void writeLangKeysToFile() {
         for (Map.Entry<String, List<String>> entry : generatedLangKeys.entrySet()) {
-            val langFile = new File("generated-lang-keys", entry.getKey() + ".txt");
+            final var langFile = new File("generated-lang-keys", entry.getKey() + ".txt");
             try {
                 FileUtils.writeLines(langFile, entry.getValue());
             } catch (IOException e) {
@@ -562,21 +559,21 @@ public class ConfigurationManager {
     }
 
     private static void cullDeadCategories() {
-        for (val entry : observedCategories.entrySet()) {
-            val config = entry.getKey();
+        for (final var entry : observedCategories.entrySet()) {
+            final var config = entry.getKey();
 
             if (!isCategoryCullingEnabled(config)) {
                 LOGGER.info("Skipping category culling for config {}", config);
                 continue;
             }
 
-            val observedCategoryNames = entry.getValue();
+            final var observedCategoryNames = entry.getValue();
 
             if (config.getCategoryNames().size() == observedCategoryNames.size()) {
                 continue;
             }
 
-            val savedCategoryNames = new ArrayList<>(config.getCategoryNames());
+            final var savedCategoryNames = new ArrayList<>(config.getCategoryNames());
             savedCategoryNames.removeIf(observedCategoryNames::contains);
 
             // Only keep the top-level category that needs removal otherwise getCategory() for any subcategory will
@@ -585,7 +582,7 @@ public class ConfigurationManager {
                     .filter(s -> savedCategoryNames.stream().noneMatch(existing -> s.startsWith(existing + ".")))
                     .collect(Collectors.toList());
 
-            for (val category : parentsToRemove) {
+            for (final var category : parentsToRemove) {
                 ConfigCategory cat = config.getCategory(category);
                 config.removeCategory(cat);
             }


### PR DESCRIPTION
Make the system more convenient to use by making `ConfigException` extend `RuntimeException`, fix a bug where string arrays would be incorrectly synced, and remove some outdated Lombok.