### PR TITLE
Fix particle keyname

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/unbaked/JSONModel.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/unbaked/JSONModel.java
@@ -328,7 +328,7 @@ public class JSONModel implements UnbakedModel {
     }
 
     protected IIcon getParticle() {
-        String key = "particle";
+        String key = "#particle";
         if (!textures.containsKey(key) && !textures.isEmpty()) {
             key = textures.keySet().iterator().next();
         }


### PR DESCRIPTION
## Fix

`ModelDeserializer.loadTextures()` stores the `"particle"` key as `"#particle"`,
but `getParticle()` looks it up as `"particle"` — causing a key mismatch.

Change the lookup key from `"particle"` to `"#particle"`.


related to https://github.com/GTNewHorizons/GTNHLib/pull/318 but that hasn't approved so I make new single PR
