### PR TITLE
Add world deletion event mixin

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/event/WorldDeletionEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/event/WorldDeletionEvent.java
@@ -4,9 +4,21 @@ import cpw.mods.fml.common.eventhandler.Event;
 
 public final class WorldDeletionEvent extends Event {
 
-    // Not a full path, name of just the directory as it is in .minecraft\saves\
     public final String worldName;
 
+    /**
+     * {@link WorldDeletionEvent} is posted on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS} a world
+     * deletion is initiated through the world selection menu in the client and the world directory name has been
+     * resolved.
+     * </p>
+     * <p>
+     * {@link #worldName} String contains the name of the world directory as it exists under {@code .minecraft/saves},
+     * this is not a full or absolute filesystem path.
+     * </p>
+     * <p>
+     * This event is not {@link cpw.mods.fml.common.eventhandler.Cancelable}.
+     * </p>
+     */
     public WorldDeletionEvent(String worldName) {
         this.worldName = worldName;
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/event/WorldDeletionEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/event/WorldDeletionEvent.java
@@ -1,5 +1,8 @@
 package com.gtnewhorizon.gtnhlib.client.event;
 
+import net.minecraftforge.common.MinecraftForge;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
 import cpw.mods.fml.common.eventhandler.Event;
 
 public final class WorldDeletionEvent extends Event {
@@ -7,16 +10,14 @@ public final class WorldDeletionEvent extends Event {
     public final String worldName;
 
     /**
-     * {@link WorldDeletionEvent} is posted on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS} a world
-     * deletion is initiated through the world selection menu in the client and the world directory name has been
-     * resolved.
+     * {@link WorldDeletionEvent} is posted on the {@link MinecraftForge#EVENT_BUS} when a world deletion is about to
+     * occur through the world selection menu on the client.
+     * <p>
+     * The {@link #worldName} field is the name of the world directory that is about to be deleted and that can be found
+     * in {@code .minecraft/saves}, this is not a full or absolute filesystem path.
      * </p>
      * <p>
-     * {@link #worldName} String contains the name of the world directory as it exists under {@code .minecraft/saves},
-     * this is not a full or absolute filesystem path.
-     * </p>
-     * <p>
-     * This event is not {@link cpw.mods.fml.common.eventhandler.Cancelable}.
+     * This event is not {@link Cancelable}.
      * </p>
      */
     public WorldDeletionEvent(String worldName) {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/event/WorldDeletionEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/event/WorldDeletionEvent.java
@@ -1,0 +1,14 @@
+package com.gtnewhorizon.gtnhlib.client.event;
+
+import cpw.mods.fml.common.eventhandler.Event;
+import lombok.Getter;
+
+public final class WorldDeletionEvent extends Event {
+
+    @Getter
+    private final String worldName;
+
+    public WorldDeletionEvent(String worldName) {
+        this.worldName = worldName;
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/event/WorldDeletionEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/event/WorldDeletionEvent.java
@@ -1,12 +1,11 @@
 package com.gtnewhorizon.gtnhlib.client.event;
 
 import cpw.mods.fml.common.eventhandler.Event;
-import lombok.Getter;
 
 public final class WorldDeletionEvent extends Event {
 
-    @Getter
-    private final String worldName;
+    // Not a full path, name of just the directory as it is in .minecraft\saves\
+    public final String worldName;
 
     public WorldDeletionEvent(String worldName) {
         this.worldName = worldName;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -57,7 +57,8 @@ public enum Mixins implements IMixins {
                     .setPhase(Phase.LATE).addCommonMixins("MixinEnhancedInfusionRecipe")
                     .addRequiredMod(TargetMods.THAUMCRAFT)),
     CONFIG_ORDER(Side.CLIENT, "fml.MixinGuiConfig"),
-    TITLE_OVERLAY(Side.CLIENT, "MixinGuiIngameForge_TitleRender", "MixinGuiIngame_TitleTick")
+    TITLE_OVERLAY(Side.CLIENT, "MixinGuiIngameForge_TitleRender", "MixinGuiIngame_TitleTick"),
+    WORLD_DELETION_EVENT(Side.CLIENT, "MixinGuiSelectWorld")
     //
     ;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinGuiSelectWorld.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinGuiSelectWorld.java
@@ -18,8 +18,7 @@ public class MixinGuiSelectWorld extends GuiScreen {
             method = "confirmClicked",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/world/storage/ISaveFormat;deleteWorldDirectory(Ljava/lang/String;)Z"),
-            index = 0)
+                    target = "Lnet/minecraft/world/storage/ISaveFormat;deleteWorldDirectory(Ljava/lang/String;)Z"))
     private String onDeleteWorldDirectoryCalled(String worldName) {
         try {
             MinecraftForge.EVENT_BUS.post(new WorldDeletionEvent(worldName));

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinGuiSelectWorld.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinGuiSelectWorld.java
@@ -1,0 +1,29 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import java.util.List;
+
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiSelectWorld;
+import net.minecraft.world.storage.SaveFormatComparator;
+import net.minecraftforge.common.MinecraftForge;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizon.gtnhlib.client.event.WorldDeletionEvent;
+
+@Mixin(value = GuiSelectWorld.class)
+public class MixinGuiSelectWorld extends GuiScreen {
+
+    @Shadow
+    private List field_146639_s;
+
+    @Inject(method = "confirmClicked", at = @At("HEAD"))
+    public void onConfirmClicked(boolean result, int id, CallbackInfo ci) {
+        String fileName = ((SaveFormatComparator) this.field_146639_s.get(id)).getFileName();
+        MinecraftForge.EVENT_BUS.post(new WorldDeletionEvent(fileName));
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinGuiSelectWorld.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinGuiSelectWorld.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
+import com.gtnewhorizon.gtnhlib.GTNHLib;
 import com.gtnewhorizon.gtnhlib.client.event.WorldDeletionEvent;
 
 @Mixin(value = GuiSelectWorld.class)
@@ -20,7 +21,11 @@ public class MixinGuiSelectWorld extends GuiScreen {
                     target = "Lnet/minecraft/world/storage/ISaveFormat;deleteWorldDirectory(Ljava/lang/String;)Z"),
             index = 0)
     private String onDeleteWorldDirectoryCalled(String worldName) {
-        MinecraftForge.EVENT_BUS.post(new WorldDeletionEvent(worldName));
+        try {
+            MinecraftForge.EVENT_BUS.post(new WorldDeletionEvent(worldName));
+        } catch (Throwable t) {
+            GTNHLib.LOG.error("Exception while posting WorldDeletionEvent", t);
+        }
         return worldName;
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinGuiSelectWorld.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinGuiSelectWorld.java
@@ -1,29 +1,26 @@
 package com.gtnewhorizon.gtnhlib.mixins.early;
 
-import java.util.List;
-
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiSelectWorld;
-import net.minecraft.world.storage.SaveFormatComparator;
 import net.minecraftforge.common.MinecraftForge;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 import com.gtnewhorizon.gtnhlib.client.event.WorldDeletionEvent;
 
 @Mixin(value = GuiSelectWorld.class)
 public class MixinGuiSelectWorld extends GuiScreen {
 
-    @Shadow
-    private List field_146639_s;
-
-    @Inject(method = "confirmClicked", at = @At("HEAD"))
-    public void onConfirmClicked(boolean result, int id, CallbackInfo ci) {
-        String fileName = ((SaveFormatComparator) this.field_146639_s.get(id)).getFileName();
-        MinecraftForge.EVENT_BUS.post(new WorldDeletionEvent(fileName));
+    @ModifyArg(
+            method = "confirmClicked",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/storage/ISaveFormat;deleteWorldDirectory(Ljava/lang/String;)Z"),
+            index = 0)
+    private String onDeleteWorldDirectoryCalled(String worldName) {
+        MinecraftForge.EVENT_BUS.post(new WorldDeletionEvent(worldName));
+        return worldName;
     }
 }


### PR DESCRIPTION
This PR create a `WorldDeletionEvent` event posted to the Minecraft Forge event bus.

The `worldName` string is the name of the currently selected world, which is also the folder name for that save.

This is an alternative approach to https://github.com/GTNewHorizons/Hodgepodge/pull/864 
It will allow to handle the cleanup in each separate mods.

