### PR TITLE
Migrate shadowed dependencies to FP DepLoader

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,20 +39,9 @@ tasks.processResources {
     }
 }
 
-// Shadow source jars too
-val shadowSources = configurations.getByName("shadowSources")
-tasks.sourcesJar {
-    from(shadowSources.map { zipTree(it) })
-    exclude("META-INF/versions/9/module-info.class")
-    exclude("META-INF/versions/9/module-info.java")
-}
-
-val jvmdgDowngraded17 = configurations.named("jvmdgDowngraded17").get()
-
 tasks.shadowJar {
     into("META-INF/versions/17") {
         from(main17.output)
-        from(zipTree(provider { jvmdgDowngraded17.files.single() }))
     }
     exclude("META-INF/versions/9/module-info.class")
 }
@@ -79,6 +68,48 @@ for (jarTask in listOf(tasks.jar, tasks.shadowJar, tasks.sourcesJar)) {
     jarTask.configure {
         manifest {
             attributes("Multi-Release" to true)
+        }
+    }
+}
+
+//deploader
+run {
+
+    tasks.processResources {
+        from(configurations["deploader"]) {
+            rename { "fplib_deploader.jar" }
+        }
+    }
+
+    fun DependencyHandlerScope.depload(name: String) {
+        add("compileOnlyApi", name)
+        add("testImplementation", name)
+        val parts = name.split(':')
+        val path = "META-INF/falsepatternlib_repo/${parts[0].replace('.', '/')}/${parts[1]}/${parts[2]}/"
+        val jarName = parts.subList(1, parts.size).joinToString("-") + ".jar"
+        tasks.processResources {
+            into(path) {
+                from(configurations.compileClasspath.map { it.filter { file -> file.name.equals(jarName) } })
+            }
+        }
+    }
+
+
+    @Suppress("UNCHECKED_CAST")
+    afterEvaluate {
+        //defined in dependencies.gradle
+        val allDeps = project.ext.get("depload_libs") as List<Pair<String, String>>
+        dependencies {
+            allDeps.forEach { depload(it.first) }
+        }
+        tasks.processResources {
+            allDeps.groupBy { it.second }
+                .mapValues { it.value.map { it.first } }
+                .forEach { (java, deps) ->
+                    filesMatching("META-INF/gtnhlib_deps${java}.json") {
+                        expand("DEPS" to deps.joinToString("\", \""))
+                    }
+                }
         }
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,20 +1,30 @@
+import kotlin.Pair
+
 // Add your dependencies here
 configurations {
-    shadowSources
-    jvmdgDowngraded17
+    deploader
 }
 
+project.ext.set("depload_libs", new ArrayList<Pair<String, String>>())
+
+def depload(String name, String java = "") {
+    List<String> theList = project.ext.get("depload_libs")
+    theList.add(new Pair(name, java))
+}
 def jvmDgVersion = "1.3.5"
 
 dependencies {
-    shadowImplementation("it.unimi.dsi:fastutil:8.5.15") // Apache 2.0
-    shadowImplementation("org.joml:joml:1.10.8") { transitive = false } // MIT
-    shadowImplementation("com.mojang:brigadier:1.0.18") // MIT
-    shadowImplementation("xyz.wagyourtail.jvmdowngrader:jvmdowngrader-java-api:${jvmDgVersion}:downgraded-8") { transitive = false } // LGPL 2.1
-    jvmdgDowngraded17("xyz.wagyourtail.jvmdowngrader:jvmdowngrader-java-api:${jvmDgVersion}:downgraded-17") { transitive = false } // LGPL 2.1
-    shadowSources("it.unimi.dsi:fastutil:8.5.15:sources")
-    shadowSources("org.joml:joml:1.10.8:sources") { transitive = false }
-    shadowSources("com.mojang:brigadier:1.0.18")
+    deploader("com.falsepattern:falsepatternlib-mc1.7.10:1.11.0:deploader") // LGPL 3.0
+    shadowImplementation("com.falsepattern:falsepatternlib-mc1.7.10:1.11.0:deploader_stub") // LGPL 3.0
+
+    //NOTE:
+    //For any given "java" version argument, make sure a corresponding gtnhlib_deps<version>.json file exists in META-INF!
+    //If you remove all depload calls for a given version argument, remove the corresponding json.
+    depload("it.unimi.dsi:fastutil:8.5.15") // Apache 2.0
+    depload("org.joml:joml:1.10.8") // MIT
+    depload("com.mojang:brigadier:1.0.18") // MIT
+    depload("xyz.wagyourtail.jvmdowngrader:jvmdowngrader-java-api:${jvmDgVersion}:downgraded-8", "8") // LGPL 2.1
+    depload("xyz.wagyourtail.jvmdowngrader:jvmdowngrader-java-api:${jvmDgVersion}:downgraded-17", "17") // LGPL 2.1
 
     testImplementation(platform("org.junit:junit-bom:5.11.4"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/gradle.properties
+++ b/gradle.properties
@@ -146,7 +146,7 @@ usesShadowedDependencies = true
 minimizeShadowedDependencies = false
 
 # If disabled, won't rename the shadowed classes.
-relocateShadowedDependencies = false
+relocateShadowedDependencies = true
 
 # Adds CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true

--- a/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/core/GTNHLibCore.java
@@ -5,10 +5,12 @@ import java.util.Map;
 import java.util.Set;
 
 import net.minecraft.launchwrapper.Launch;
+import net.minecraft.launchwrapper.LaunchClassLoader;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.falsepattern.deploader.DeploaderStub;
 import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
 import com.gtnewhorizon.gtnhlib.config.ConfigException;
 import com.gtnewhorizon.gtnhlib.config.ConfigurationManager;
@@ -24,6 +26,21 @@ import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
         "com.gtnewhorizon.gtnhlib.core", "com.gtnewhorizon.gtnhlib.client.renderer.TessellatorManager",
         "com.gtnewhorizon.gtnhlib.client.renderer.CapturingTessellator" })
 public class GTNHLibCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
+
+    static {
+        try {
+            var cleF = LaunchClassLoader.class.getDeclaredField("classLoaderExceptions");
+            cleF.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            var cle = (Set<String>) cleF.get(Launch.classLoader);
+            // for Brigadier
+            cle.remove("com.mojang.");
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        DeploaderStub.bootstrap(false);
+        DeploaderStub.runDepLoader();
+    }
 
     /// Lifted here so we can safely use it in Mixins. This class should be loaded by the time Mixins fire.
     public static final Logger MODEL_LOGGER = LogManager.getLogger("GTNHLib|Models");

--- a/src/main/java/com/gtnewhorizon/gtnhlib/core/rfb/GTNHLibRfbPlugin.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/core/rfb/GTNHLibRfbPlugin.java
@@ -5,6 +5,7 @@ import net.minecraft.launchwrapper.Launch;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import com.falsepattern.deploader.DeploaderStub;
 import com.gtnewhorizon.gtnhlib.core.rfb.transformers.RFBTessellatorRedirectorWrapper;
 import com.gtnewhorizon.gtnhlib.core.rfb.transformers.RFBTessellatorTransformerWrapper;
 import com.gtnewhorizons.retrofuturabootstrap.api.PluginContext;
@@ -13,6 +14,11 @@ import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
 import com.gtnewhorizons.retrofuturabootstrap.api.RfbPlugin;
 
 public class GTNHLibRfbPlugin implements RfbPlugin {
+
+    static {
+        DeploaderStub.bootstrap(true);
+        DeploaderStub.runDepLoader();
+    }
 
     @Override
     public void onConstruction(@NotNull PluginContext ctx) {

--- a/src/main/resources/META-INF/gtnhlib_deps.json
+++ b/src/main/resources/META-INF/gtnhlib_deps.json
@@ -1,0 +1,8 @@
+{
+    "identifier": "falsepatternlib_dependencies",
+    "dependencies": {
+        "always": {
+            "common": ["$DEPS"]
+        }
+    }
+}

--- a/src/main/resources/META-INF/gtnhlib_deps17.json
+++ b/src/main/resources/META-INF/gtnhlib_deps17.json
@@ -1,0 +1,9 @@
+{
+    "identifier": "falsepatternlib_dependencies",
+    "minJava": 17,
+    "dependencies": {
+        "always": {
+            "common": ["$DEPS"]
+        }
+    }
+}

--- a/src/main/resources/META-INF/gtnhlib_deps8.json
+++ b/src/main/resources/META-INF/gtnhlib_deps8.json
@@ -1,0 +1,9 @@
+{
+    "identifier": "falsepatternlib_dependencies",
+    "maxJava": 16,
+    "dependencies": {
+        "always": {
+            "common": ["$DEPS"]
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/GTNewHorizons/GTNHLib/issues/336

All of the previously shaded-in dependencies are embedded as JarInJar-style files, so the deploader does not need a network connection and is functionally equivalent to the shadowed approach, except now it can cooperate with other mods that use deploader (falsetweaks, etc.).

The shadowed libraries were not updated in this PR to minimize any potential chance of unwanted side effects.