### PR TITLE
redo ITeamData#copyData signature

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/teams/ITeamData.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/teams/ITeamData.java
@@ -4,8 +4,6 @@ import java.util.UUID;
 
 import net.minecraft.nbt.NBTTagCompound;
 
-import org.jetbrains.annotations.Nullable;
-
 public interface ITeamData {
 
     void writeToNBT(NBTTagCompound tag);
@@ -23,11 +21,11 @@ public interface ITeamData {
     /**
      * Called when a player moves from one team to another.
      *
-     * @return The copied ITeamData or null if no data should be copied.
+     * @param playerId     UUID of the player who is moving teams
+     * @param prevTeamData ITeamData of the previous team
      */
-    default @Nullable ITeamData copyData(Team oldTeam, Team newTeam, UUID playerId, TeamDataCopyReason reason) {
-        return null;
-    }
+    default void copyData(Team prevTeam, Team newTeam, UUID playerId, ITeamData prevTeamData,
+            TeamDataCopyReason reason) {}
 
     ITeamData UNIMPLEMENTED = new ITeamData() {
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamManager.java
@@ -115,12 +115,9 @@ public class TeamManager {
         consumed.markRemoved();
     }
 
-    public static void copyTeamData(Team oldTeam, Team newTeam, UUID playerId, TeamDataCopyReason reason) {
-        for (Entry<String, ITeamData> entry : oldTeam.getAllDataEntries()) {
-            ITeamData copied = entry.getValue().copyData(oldTeam, newTeam, playerId, reason);
-            if (copied != null) {
-                newTeam.putData(entry.getKey(), copied);
-            }
+    public static void copyTeamData(Team prevTeam, Team newTeam, UUID playerId, TeamDataCopyReason reason) {
+        for (Entry<String, ITeamData> entry : newTeam.getAllDataEntries()) {
+            entry.getValue().copyData(prevTeam, newTeam, playerId, prevTeam.getData(entry.getKey()), reason);
         }
     }
 


### PR DESCRIPTION
The previous copyData didn't really make any sense. The new changes make it similar to mergeData:
- Called on the destination team data
- Passes in prevTeamData
- Doesn't return anything

Currently, no mods use this library and I would like to get this change in before any do