### PR TITLE
Fix team names with spaces not working due to greedystring

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamAdminCommand.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamAdminCommand.java
@@ -38,8 +38,8 @@ public class TeamAdminCommand {
                         })
                         .then(
                                 literal("rename").then(
-                                        argument(ARG_TEAM_NAME, StringArgumentType.word()).then(
-                                                argument(ARG_NEW_NAME, StringArgumentType.greedyString()).executes(
+                                        argument(ARG_TEAM_NAME, StringArgumentType.string()).then(
+                                                argument(ARG_NEW_NAME, StringArgumentType.string()).executes(
                                                         ctx -> executeAdminRename(
                                                                 ctx.getSource(),
                                                                 StringArgumentType.getString(ctx, ARG_TEAM_NAME),
@@ -70,13 +70,13 @@ public class TeamAdminCommand {
                                                                 StringArgumentType.getString(ctx, ARG_TEAM_NAME))))))
                         .then(
                                 literal("disband").then(
-                                        argument(ARG_TEAM_NAME, StringArgumentType.greedyString()).executes(
+                                        argument(ARG_TEAM_NAME, StringArgumentType.string()).executes(
                                                 ctx -> executeAdminDisband(
                                                         ctx.getSource(),
                                                         StringArgumentType.getString(ctx, ARG_TEAM_NAME)))))
                         .then(
                                 literal("info").then(
-                                        argument(ARG_TEAM_NAME, StringArgumentType.greedyString()).executes(
+                                        argument(ARG_TEAM_NAME, StringArgumentType.string()).executes(
                                                 ctx -> executeAdminInfo(
                                                         ctx.getSource(),
                                                         StringArgumentType.getString(ctx, ARG_TEAM_NAME)))))

--- a/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamCommand.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamCommand.java
@@ -39,7 +39,7 @@ public class TeamCommand {
             return Command.SINGLE_SUCCESS;
         }).then(
                 literal("rename").then(
-                        argument(ARG_NEW_NAME, StringArgumentType.greedyString()).executes(
+                        argument(ARG_NEW_NAME, StringArgumentType.string()).executes(
                                 ctx -> executeRename(
                                         ctx.getSource(),
                                         StringArgumentType.getString(ctx, ARG_NEW_NAME)))))
@@ -58,7 +58,7 @@ public class TeamCommand {
 
                 .then(
                         literal("accept").executes(ctx -> executeAccept(ctx.getSource(), "")).then(
-                                argument(ARG_TEAM_NAME, StringArgumentType.greedyString())
+                                argument(ARG_TEAM_NAME, StringArgumentType.string())
                                         .suggests((ctx, builder) -> suggestPendingInvites(ctx.getSource(), builder))
                                         .executes(
                                                 ctx -> executeAccept(
@@ -67,7 +67,7 @@ public class TeamCommand {
 
                 .then(
                         literal("deny").executes(ctx -> executeDeny(ctx.getSource(), "")).then(
-                                argument(ARG_TEAM_NAME, StringArgumentType.greedyString())
+                                argument(ARG_TEAM_NAME, StringArgumentType.string())
                                         .suggests((ctx, builder) -> suggestPendingInvites(ctx.getSource(), builder))
                                         .executes(
                                                 ctx -> executeDeny(
@@ -100,7 +100,7 @@ public class TeamCommand {
                         literal("merge")
                                 .then(
                                         literal("request").then(
-                                                argument(ARG_TEAM_NAME, StringArgumentType.greedyString()).suggests(
+                                                argument(ARG_TEAM_NAME, StringArgumentType.string()).suggests(
                                                         (ctx, builder) -> suggestOtherTeams(ctx.getSource(), builder))
                                                         .executes(
                                                                 ctx -> executeMergeRequest(
@@ -110,7 +110,7 @@ public class TeamCommand {
                                 .then(
                                         literal("accept").executes(ctx -> executeMergeAccept(ctx.getSource(), ""))
                                                 .then(
-                                                        argument(ARG_TEAM_NAME, StringArgumentType.greedyString())
+                                                        argument(ARG_TEAM_NAME, StringArgumentType.string())
                                                                 .suggests(
                                                                         (ctx, builder) -> suggestPendingMerges(
                                                                                 ctx.getSource(),
@@ -124,7 +124,7 @@ public class TeamCommand {
                                 .then(
                                         literal("deny").executes(ctx -> executeMergeDeny(ctx.getSource(), ""))
                                                 .then(
-                                                        argument(ARG_TEAM_NAME, StringArgumentType.greedyString())
+                                                        argument(ARG_TEAM_NAME, StringArgumentType.string())
                                                                 .suggests(
                                                                         (ctx, builder) -> suggestPendingMerges(
                                                                                 ctx.getSource(),

--- a/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamCommand.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamCommand.java
@@ -190,8 +190,8 @@ public class TeamCommand {
                 "gtnhlib.chat.teams.message.received_invite",
                 colorChatComponent(EnumChatFormatting.GOLD, player.getCommandSenderName()),
                 colorChatComponent(EnumChatFormatting.GOLD, team.getTeamName()),
-                colorChatComponent(EnumChatFormatting.YELLOW, "/gtnhteam accept " + team.getTeamName()),
-                colorChatComponent(EnumChatFormatting.YELLOW, "/gtnhteam deny " + team.getTeamName()));
+                colorChatComponent(EnumChatFormatting.YELLOW, "/gtnhteam accept \"" + team.getTeamName() + "\""),
+                colorChatComponent(EnumChatFormatting.YELLOW, "/gtnhteam deny \"" + team.getTeamName() + "\""));
         notification.getChatStyle().setColor(EnumChatFormatting.GREEN);
         target.addChatMessage(notification);
 
@@ -440,8 +440,10 @@ public class TeamCommand {
         ChatComponentTranslation notification = new ChatComponentTranslation(
                 "gtnhlib.chat.teams.message.merge_request_received",
                 sourceComponent,
-                colorChatComponent(EnumChatFormatting.YELLOW, "/gtnhteam merge accept " + source.getTeamName()),
-                colorChatComponent(EnumChatFormatting.YELLOW, "/gtnhteam merge deny " + source.getTeamName()));
+                colorChatComponent(
+                        EnumChatFormatting.YELLOW,
+                        "/gtnhteam merge accept \"" + source.getTeamName() + "\""),
+                colorChatComponent(EnumChatFormatting.YELLOW, "/gtnhteam merge deny \"" + source.getTeamName() + "\""));
         notification.getChatStyle().setColor(EnumChatFormatting.GREEN);
 
         for (UUID ownerUuid : target.getOwners()) {


### PR DESCRIPTION
This PR aims to Fix #345.

Team names with spaces in them had some issues. For simplicity, if team names have spaces they must now have quotes around them in order to get caught by the quotable string arguments. 
Single-word teamnames don't require quotes still.

Some of the commands like the force-disband or self-rename technically don't need the quotes, but I feel like this might just become a source of user confusion if we allow that.