### PR TITLE
Catch same team mergers and fix command

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamAdminCommand.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamAdminCommand.java
@@ -3,6 +3,7 @@ package com.gtnewhorizon.gtnhlib.teams;
 import static com.gtnewhorizon.gtnhlib.teams.TeamCommandsUtils.ARG_NEW_NAME;
 import static com.gtnewhorizon.gtnhlib.teams.TeamCommandsUtils.ARG_PLAYER;
 import static com.gtnewhorizon.gtnhlib.teams.TeamCommandsUtils.ARG_TEAM_NAME;
+import static com.gtnewhorizon.gtnhlib.teams.TeamCommandsUtils.ARG_TEAM_NAME_OTHER;
 import static com.gtnewhorizon.gtnhlib.teams.TeamCommandsUtils.resolveTeamMemberUuid;
 import static com.gtnewhorizon.gtnhlib.util.CommandUtils.argument;
 import static com.gtnewhorizon.gtnhlib.util.CommandUtils.colorChatComponent;
@@ -63,11 +64,12 @@ public class TeamAdminCommand {
                         .then(
                                 literal("merge").then(
                                         argument(ARG_TEAM_NAME, StringArgumentType.string()).then(
-                                                argument(ARG_TEAM_NAME, StringArgumentType.string()).executes(
+                                                argument(ARG_TEAM_NAME_OTHER, StringArgumentType.string()).executes(
                                                         ctx -> executeAdminMerge(
                                                                 ctx.getSource(),
                                                                 StringArgumentType.getString(ctx, ARG_TEAM_NAME),
-                                                                StringArgumentType.getString(ctx, ARG_TEAM_NAME))))))
+                                                                StringArgumentType
+                                                                        .getString(ctx, ARG_TEAM_NAME_OTHER))))))
                         .then(
                                 literal("disband").then(
                                         argument(ARG_TEAM_NAME, StringArgumentType.string()).executes(
@@ -146,6 +148,10 @@ public class TeamAdminCommand {
         if (sourceTeam == null) return error(sender, "gtnhlib.chat.teams.admin.error.team_not_found", sourceName);
         Team targetTeam = TeamManager.getTeamByName(targetName);
         if (targetTeam == null) return error(sender, "gtnhlib.chat.teams.admin.error.team_not_found", targetName);
+
+        if (sourceTeam.getTeamId().equals(targetTeam.getTeamId())) {
+            return error(sender, "gtnhlib.chat.teams.admin.message.merge_teams_same");
+        }
 
         List<UUID> allMembers = new ArrayList<>(sourceTeam.getMembers());
         allMembers.addAll(targetTeam.getMembers());

--- a/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamCommandsUtils.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamCommandsUtils.java
@@ -20,6 +20,7 @@ import com.gtnewhorizon.gtnhlib.util.CommandUtils;
 public abstract class TeamCommandsUtils {
 
     static final String ARG_TEAM_NAME = "teamName";
+    static final String ARG_TEAM_NAME_OTHER = "otherTeamName";
     static final String ARG_NEW_NAME = "newName";
     static final String ARG_PLAYER = "player";
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamManager.java
@@ -94,6 +94,10 @@ public class TeamManager {
      * disbanded afterward.
      */
     public static void mergeTeams(Team surviving, Team consumed) {
+        if (surviving.getTeamId().equals(consumed.getTeamId())) {
+            GTNHLib.LOG.error("Cannot merge team into itself.");
+            return;
+        }
         for (UUID uuid : consumed.getMembers()) {
             PLAYER_TEAM_CACHE.put(uuid, surviving);
             surviving.addMember(uuid);

--- a/src/main/resources/assets/gtnhlib/lang/en_US.lang
+++ b/src/main/resources/assets/gtnhlib/lang/en_US.lang
@@ -196,6 +196,7 @@ gtnhlib.chat.teams.admin.error.demote_last_owner=%s cannot be force-demoted as l
 gtnhlib.chat.teams.admin.message.usage=GTNHTeams Admin commands: help, info, rename, promote, demote, merge, disband
 gtnhlib.chat.teams.admin.message.renamed=Team %s was force-renamed to %s.
 gtnhlib.chat.teams.admin.message.merged=Team %s was force-merged into %s.
+gtnhlib.chat.teams.admin.message.merge_teams_same=Can't merge a team into itself!
 gtnhlib.chat.teams.admin.message.team_disbanded=%s was forcibly disbanded by an administrator.
 gtnhlib.chat.teams.admin.message.disbanded=%s was force-disbanded.
 gtnhlib.chat.teams.admin.message.promoted_to_owner=%s was force-promoted to an owner of %s.


### PR DESCRIPTION
When using the admin force-merge, the target team was being merged into itself and then voided. This PR fixes it, and adds a couple sanity checks in the command and the actual merge code.