### PR TITLE
add u (drop shadow) to isValidAmpCode

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/font/FontRendering.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/font/FontRendering.java
@@ -101,7 +101,8 @@ public class FontRendering {
                 || cl == 'x'
                 || cl == 'q'
                 || cl == 'z'
-                || cl == 'v';
+                || cl == 'v'
+                || cl == 'u';
         // Note: 'g' excluded — &g only valid as part of &g&#RRGGBB&#RRGGBB (handled by isAmpGradient)
     }
 


### PR DESCRIPTION
adds &u to isValidAmpCode so width/size/trim methods skip &u as zero-width.

part of the drop shadow feature. &u toggles per-segment shadow, &u&#RRGGBB sets custom shadow color.