### PR TITLE
LivingEquipmentChangeEvent init detection

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/event/LivingEquipmentChangeEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/event/LivingEquipmentChangeEvent.java
@@ -12,6 +12,7 @@ public class LivingEquipmentChangeEvent extends LivingEvent {
     private final int slot;
     private final ItemStack from;
     private final ItemStack to;
+    private final boolean initial;
 
     /**
      * {@link LivingEquipmentChangeEvent} is fired when the Equipment of an Entity changes. <br>
@@ -29,7 +30,7 @@ public class LivingEquipmentChangeEvent extends LivingEvent {
      * </ul>
      * {@link #from} contains the {@link ItemStack} that was equipped previously. <br>
      * {@link #to} contains the {@link ItemStack} that is equipped now. <br>
-     * <br>
+     * {@link #initial} is {@link Boolean#TRUE} if this entity is firing this event through its first tick. <br>
      * This event is not {@link cpw.mods.fml.common.eventhandler.Cancelable}. <br>
      * <br>
      * This event does not have a result. {@link HasResult} <br>
@@ -37,11 +38,22 @@ public class LivingEquipmentChangeEvent extends LivingEvent {
      * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.
      **/
 
-    public LivingEquipmentChangeEvent(EntityLivingBase entity, int slot, ItemStack from, ItemStack to) {
+    public LivingEquipmentChangeEvent(EntityLivingBase entity, int slot, ItemStack from, ItemStack to,
+            boolean initial) {
         super(entity);
         this.slot = slot;
         this.from = from;
         this.to = to;
+        this.initial = initial;
+    }
+
+    /**
+     * Constructor that always assumes this is not the initial event firing. See
+     * {@link LivingEquipmentChangeEvent#LivingEquipmentChangeEvent(EntityLivingBase, int, ItemStack, ItemStack, boolean)}
+     * for full javadoc.
+     **/
+    public LivingEquipmentChangeEvent(EntityLivingBase entity, int slot, ItemStack from, ItemStack to) {
+        this(entity, slot, from, to, false);
     }
 
     /**
@@ -64,5 +76,9 @@ public class LivingEquipmentChangeEvent extends LivingEvent {
 
     public ItemStack getTo() {
         return this.to;
+    }
+
+    public boolean isInitial() {
+        return initial;
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinEntityLivingBase.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinEntityLivingBase.java
@@ -1,7 +1,9 @@
 package com.gtnewhorizon.gtnhlib.mixins.early;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -10,9 +12,20 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.gtnewhorizon.gtnhlib.client.event.LivingEquipmentChangeEvent;
 import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 
 @Mixin(EntityLivingBase.class)
-public class MixinEntityLivingBase {
+public abstract class MixinEntityLivingBase extends Entity {
+
+    public MixinEntityLivingBase(World worldIn) {
+        super(worldIn);
+    }
+
+    @Inject(method = "onUpdate", at = @At(value = "HEAD"))
+    private void catchFirstUpdate(CallbackInfo ci, @Share("prevFirstUpdate") LocalBooleanRef prevFirstUpdate) {
+        prevFirstUpdate.set(firstUpdate);
+    }
 
     @Inject(
             method = "onUpdate",
@@ -20,8 +33,14 @@ public class MixinEntityLivingBase {
                     value = "INVOKE_ASSIGN",
                     target = "Lnet/minecraft/world/WorldServer;getEntityTracker()Lnet/minecraft/entity/EntityTracker;"))
     private void addEquipmentChangeEventBus(CallbackInfo ci, @Local(ordinal = 1) int slot,
-            @Local(ordinal = 0) ItemStack prevItem, @Local(ordinal = 1) ItemStack newItem) {
-        net.minecraftforge.common.MinecraftForge.EVENT_BUS
-                .post(new LivingEquipmentChangeEvent((EntityLivingBase) (Object) this, slot, prevItem, newItem));
+            @Local(ordinal = 0) ItemStack prevItem, @Local(ordinal = 1) ItemStack newItem,
+            @Share("prevFirstUpdate") LocalBooleanRef prevFirstUpdate) {
+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(
+                new LivingEquipmentChangeEvent(
+                        (EntityLivingBase) (Object) this,
+                        slot,
+                        prevItem,
+                        newItem,
+                        prevFirstUpdate.get()));
     }
 }

--- a/src/main/resources/META-INF/gtnhlib_at.cfg
+++ b/src/main/resources/META-INF/gtnhlib_at.cfg
@@ -26,3 +26,4 @@ public net.minecraft.command.CommandHandler field_71562_a # commandMap
 public net.minecraft.util.RegistrySimple field_82596_a # registryObjects
 public net.minecraft.nbt.NBTTagCompound field_74784_a # tagMap
 public net.minecraft.nbt.NBTTagList field_74747_a # tagList
+public net.minecraft.entity.Entity field_70148_d # firstUpdate


### PR DESCRIPTION
Added a proper way to detect when an entity is being initialized in LivingEquipmentChangeEvent.

Fixes #361 by adding proper detection while keeping current behavior for existing code.