### PR TITLE
Put BlockPropertyRegistry.getGenericInterfaces() into try/catch

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/blockstate/registry/BlockPropertyRegistry.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/blockstate/registry/BlockPropertyRegistry.java
@@ -190,9 +190,11 @@ public class BlockPropertyRegistry {
             IFACE_PROPERTIES.copyAll(curr, cache);
 
             if (curr instanceof Class<?>clazz2) {
-                for (Type iface : clazz2.getGenericInterfaces()) {
-                    queue.addAndMoveToFirst(iface);
-                }
+                try {
+                    for (Type iface : clazz2.getGenericInterfaces()) {
+                        queue.addAndMoveToFirst(iface);
+                    }
+                } catch (TypeNotPresentException ignored) {}
 
                 for (Type iface : clazz2.getInterfaces()) {
                     queue.addAndMoveToFirst(iface);


### PR DESCRIPTION
`BlockPropertyRegistry.getGenericInterfaces()` crashes on optional interfaces when one of them doesn't resolve. A proper fix would be going over generic interfaces with ASM and do the checks there, but IG this is ok as a first fix.