### PR TITLE
Move `canInsert` check before `maxStack`.

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/item/StandardInventoryIterator.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/item/StandardInventoryIterator.java
@@ -109,6 +109,10 @@ public class StandardInventoryIterator extends AbstractInventoryIterator {
 
         ItemStack partialCopy = stack.toStackFast();
 
+        if (!forced && !canInsert(partialCopy, slotIndex)) {
+            return stack.getStackSize();
+        }
+
         int maxStack = getSlotStackLimit(slotIndex, partialCopy);
 
         if (!ItemUtil.isStackEmpty(inSlot)) {
@@ -121,13 +125,6 @@ public class StandardInventoryIterator extends AbstractInventoryIterator {
             if (!stack.matches(inSlot)) {
                 return stack.getStackSize();
             }
-        }
-
-        if (!forced && !canInsert(partialCopy, slotIndex)) {
-            return stack.getStackSize();
-        }
-
-        if (!ItemUtil.isStackEmpty(inSlot)) {
             int toInsert = forced ? stack.getStackSize() : Math.min(maxStack - inSlot.stackSize, stack.getStackSize());
 
             ItemStack toInsertStack = inSlot.copy();


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25193

Although the root cause of the issue is ExtraUtilities having a O(n) `getInventoryStackLimit`, this should be enough of a workaround.