### PR TITLE
wrap ChatComponentItemName text in brackets like vanilla func_151000_E()

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/chat/customcomponents/ChatComponentItemName.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/chat/customcomponents/ChatComponentItemName.java
@@ -29,7 +29,8 @@ public class ChatComponentItemName extends AbstractChatComponentBuffer<ChatCompo
 
     @Override
     public String getUnformattedTextForChat() {
-        return stack == null ? "" : stack.getDisplayName();
+        // Wrap in brackets like vanilla func_151000_E(), but resolved client-side in the correct locale.
+        return stack == null ? "" : "[" + stack.getDisplayName() + "]";
     }
 
     @Override


### PR DESCRIPTION
getUnformattedTextForChat() returned just the item name without brackets, unlike vanilla func_151000_E() which wraps it in [brackets]. This made the chat component indistinguishable from plain text. Wrapped in brackets so it matches vanilla format and can be reliably identified in chat.