### PR TITLE
Fix ItemTransfer retry loop with size-dependent filters

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/item/ItemTransfer.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/item/ItemTransfer.java
@@ -182,7 +182,8 @@ public class ItemTransfer {
                         }
                     }
 
-                    continue;
+                    // Skip this slot to avoid retrying the same extraction as the previous iteration.
+                    break;
                 }
 
                 // Try to insert the extracted stack

--- a/src/main/java/com/gtnewhorizon/gtnhlib/item/ItemTransfer.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/item/ItemTransfer.java
@@ -154,8 +154,12 @@ public class ItemTransfer {
                 int remainingTransferAllowance = maxTotalTransferred - itemsTransferred;
 
                 int toTransferThisOP = Math.min(remainingTransferAllowance, maxItemsPerTransfer);
+                int toExtract = Math.min(availableCount, toTransferThisOP);
 
-                ItemStack extracted = iter.extract(Math.min(availableCount, toTransferThisOP), false);
+                // Filters may depend on stack size. Re-check the exact amount about to be extracted.
+                if (filter != null && !filter.test(insertion.set(available, toExtract))) break;
+
+                ItemStack extracted = iter.extract(toExtract, false);
 
                 // We couldn't extract anything, even though we should've been able to: go to the next source slot
                 if (ItemUtil.isStackEmpty(extracted)) break;


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25297

Fixes an ItemTransfer infinite loop where a slot could pass a size-dependent filter with its full stack size, then fail the same filter after extracting a smaller chunk from that slot.

MTEBuffer sets a size-dependent filter.
https://github.com/GTNewHorizons/GT5-Unofficial/blob/33b63536d64198e761f0d9cb8e904af52f1519ca/src/main/java/gregtech/api/metatileentity/implementations/MTEBuffer.java#L444