### PR TITLE
Update team commands

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamActions.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/teams/TeamActions.java
@@ -44,7 +44,11 @@ public class TeamActions {
     }
 
     public static void onInvite(Team team, EntityPlayer source, EntityPlayer target) {
-        TeamManager.addPendingInvite(target.getUniqueID(), team);
+        UUID targetId = target.getUniqueID();
+        TeamManager.addPendingInvite(targetId, team);
+
+        String displayTeamName = TeamManager.getPendingInvites(targetId).size() == 1 ? ""
+                : " \"" + team.getTeamName() + "\"";
 
         ChatComponentTranslation notification = new ChatComponentTranslation(
                 "gtnhlib.chat.teams.message.received_invite",
@@ -52,10 +56,10 @@ public class TeamActions {
                 colorChatComponent(EnumChatFormatting.GOLD, team.getTeamName()),
                 colorChatComponent(
                         EnumChatFormatting.YELLOW,
-                        TeamCommandsUtils.getCommandRoot() + " accept \"" + team.getTeamName() + "\""),
+                        TeamCommandsUtils.getCommandRoot() + " accept" + displayTeamName),
                 colorChatComponent(
                         EnumChatFormatting.YELLOW,
-                        TeamCommandsUtils.getCommandRoot() + " deny \"" + team.getTeamName() + "\""));
+                        TeamCommandsUtils.getCommandRoot() + " deny" + displayTeamName));
         notification.getChatStyle().setColor(EnumChatFormatting.GREEN);
         target.addChatMessage(notification);
 
@@ -273,16 +277,19 @@ public class TeamActions {
         ChatComponentText targetComponent = colorChatComponent(EnumChatFormatting.GOLD, target.getTeamName());
         success(player, "gtnhlib.chat.teams.message.merge_request_sent", targetComponent);
 
+        String requesterTeamDisplay = TeamManager.getPendingMergeRequests(target).size() == 1 ? ""
+                : " \"" + source.getTeamName() + "\"";
+
         // Notify all online owners of the target team
         ChatComponentTranslation notification = new ChatComponentTranslation(
                 "gtnhlib.chat.teams.message.merge_request_received",
                 sourceComponent,
                 colorChatComponent(
                         EnumChatFormatting.YELLOW,
-                        TeamCommandsUtils.getCommandRoot() + " merge accept \"" + source.getTeamName() + "\""),
+                        TeamCommandsUtils.getCommandRoot() + " merge accept" + requesterTeamDisplay),
                 colorChatComponent(
                         EnumChatFormatting.YELLOW,
-                        TeamCommandsUtils.getCommandRoot() + " merge deny \"" + source.getTeamName() + "\""));
+                        TeamCommandsUtils.getCommandRoot() + " merge deny" + requesterTeamDisplay));
         notification.getChatStyle().setColor(EnumChatFormatting.GREEN);
         Set<UUID> owners = target.getOwners();
         TeamManager.forEachOnlineTeamMember(target, member -> {


### PR DESCRIPTION
Makes it so the suggested command to accept a team invite/merge will only show the team name if there's more than one active invite. Otherwise it'll just show the base accept/reject command.

<img width="672" height="148" alt="image" src="https://github.com/user-attachments/assets/2f272895-97fe-40d9-8a8a-373929f2ead3" />
