### PR TITLE
Remove threadsafe annotation from ModelISBRH

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/ModelISBRH.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/ModelISBRH.java
@@ -41,12 +41,10 @@ import com.gtnewhorizon.gtnhlib.client.renderer.cel.model.quad.ModelQuadView;
 import com.gtnewhorizon.gtnhlib.client.renderer.cel.model.quad.properties.ModelQuadFacing;
 import com.gtnewhorizon.gtnhlib.core.fml.transformers.BlockIconTransformer;
 import com.gtnewhorizon.gtnhlib.util.StdLCG;
-import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 
-@ThreadSafeISBRH(perThread = true)
 public class ModelISBRH implements ISimpleBlockRenderingHandler, IItemRenderer {
 
     public static final ThreadLocal<ModelISBRH> INSTANCE = ThreadLocal.withInitial(ModelISBRH::new);

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/ModelISBRH.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/ModelISBRH.java
@@ -45,6 +45,8 @@ import com.gtnewhorizon.gtnhlib.util.StdLCG;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 
+// TODO: Fix thread safety issues in blockstates
+// @ThreadSafeISBRH(perThread = true)
 public class ModelISBRH implements ISimpleBlockRenderingHandler, IItemRenderer {
 
     public static final ThreadLocal<ModelISBRH> INSTANCE = ThreadLocal.withInitial(ModelISBRH::new);


### PR DESCRIPTION
This ISBRH relies on Blockstates, and Blockstate access is not thread-safe. If this annotation is present alongside Angelica, models will constantly cause fatal crashes.

Ideally the thread safety issues in Blockstates are fixed, but I don't have enough knowledge of that system to even begin to know where to look - for now, the models are _not_ thread-safe, so we shouldn't be annotating as if they are.

Verified that models are compatible with Angelica with annotation removed.