### PR TITLE
Add world conversion warning system

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,11 @@ tasks.jar.configure {
     dependsOn(main17.compileJavaTaskName)
     into("META-INF/versions/17") { from(main17.output) }
 }
+tasks.jar {
+    manifest {
+        attributes["MixinConfigs"] = "mixins.gtnhlib.preinit.json"
+    }
+}
 tasks.sourcesJar.configure {
     into("META-INF/versions/17") { from(main17.java.sourceDirectories) }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/GuiConfirmationWCW.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/GuiConfirmationWCW.java
@@ -1,0 +1,26 @@
+package com.gtnewhorizon.gtnhlib.api.gui;
+
+import net.minecraft.client.gui.GuiOptionButton;
+import net.minecraft.client.resources.I18n;
+
+import cpw.mods.fml.client.GuiConfirmation;
+import cpw.mods.fml.common.StartupQuery;
+
+/**
+ * The default missing mapping gui but with the yes/no buttons moved up. We need to use this because FML made these guis
+ * run at very low fps, which could make the user think the gui isn't registering their clicks and prompt them to click
+ * again, and accidentally skip past the missing mapping gui without reading it.
+ */
+@SuppressWarnings("unused")
+public class GuiConfirmationWCW extends GuiConfirmation {
+
+    public GuiConfirmationWCW(StartupQuery query) {
+        super(query);
+    }
+
+    public void initGui() {
+        this.buttonList.add(new GuiOptionButton(0, this.width / 2 - 155, this.height - 58, I18n.format("gui.yes")));
+        this.buttonList
+                .add(new GuiOptionButton(1, this.width / 2 - 155 + 160, this.height - 58, I18n.format("gui.no")));
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/IWorldConversionWarning.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/IWorldConversionWarning.java
@@ -41,5 +41,7 @@ public interface IWorldConversionWarning {
      * @return Gui to be used in the warning. null to use default.
      */
     @SideOnly(Side.CLIENT)
-    GuiConfirmationWCW getGui(StartupQuery startupQuery);
+    default GuiConfirmationWCW getGui(StartupQuery startupQuery) {
+        return null;
+    }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/IWorldConversionWarning.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/IWorldConversionWarning.java
@@ -4,7 +4,7 @@ import cpw.mods.fml.common.StartupQuery;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public abstract class WorldConversionWarning {
+public interface IWorldConversionWarning {
 
     /**
      * Will be called right after {@link cpw.mods.fml.common.event.FMLMissingMappingsEvent}s are fired to determine if
@@ -12,14 +12,14 @@ public abstract class WorldConversionWarning {
      *
      * @return True if the warning should be shown
      */
-    public abstract boolean shouldShow();
+    boolean shouldShow();
 
     /**
      * Server-side only a simple text message will be printed.
      *
      * @return The text message
      */
-    public abstract String getServerMessage();
+    String getServerMessage();
 
     /**
      * Client-side you can choose to either supply a custom {@link com.gtnewhorizon.gtnhlib.api.gui.GuiConfirmationWCW}
@@ -29,7 +29,7 @@ public abstract class WorldConversionWarning {
      * @return The text message for default gui class
      */
     @SideOnly(Side.CLIENT)
-    public abstract String getClientMessage();
+    String getClientMessage();
 
     /**
      * Children MUST annotate with @SideOnly(Side.CLIENT)
@@ -41,5 +41,5 @@ public abstract class WorldConversionWarning {
      * @return Gui to be used in the warning. null to use default.
      */
     @SideOnly(Side.CLIENT)
-    public abstract GuiConfirmationWCW getGui(StartupQuery startupQuery);
+    GuiConfirmationWCW getGui(StartupQuery startupQuery);
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/WCWHelper.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/WCWHelper.java
@@ -1,0 +1,20 @@
+package com.gtnewhorizon.gtnhlib.api.gui;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.StartupQuery;
+
+public class WCWHelper {
+
+    @ApiStatus.Internal
+    public static void fireWarnings() {
+        WorldConversionWarningManager.WARNINGS.forEach((id, wcw) -> {
+            if (wcw.shouldShow()) {
+                boolean confirmed = StartupQuery
+                        .confirm(FMLCommonHandler.instance().getSide().isServer() ? wcw.getServerMessage() : id);
+                if (!confirmed) StartupQuery.abort();
+            }
+        });
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/WorldConversionWarning.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/WorldConversionWarning.java
@@ -1,0 +1,45 @@
+package com.gtnewhorizon.gtnhlib.api.gui;
+
+import cpw.mods.fml.common.StartupQuery;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public abstract class WorldConversionWarning {
+
+    /**
+     * Will be called right after {@link cpw.mods.fml.common.event.FMLMissingMappingsEvent}s are fired to determine if
+     * the warning should be shown.
+     *
+     * @return True if the warning should be shown
+     */
+    public abstract boolean shouldShow();
+
+    /**
+     * Server-side only a simple text message will be printed.
+     *
+     * @return The text message
+     */
+    public abstract String getServerMessage();
+
+    /**
+     * Client-side you can choose to either supply a custom {@link com.gtnewhorizon.gtnhlib.api.gui.GuiConfirmationWCW}
+     * or the default one with a text message. To show a default
+     * {@link com.gtnewhorizon.gtnhlib.api.gui.GuiConfirmationWCW} return null in {@link #getGui(StartupQuery)}.
+     *
+     * @return The text message for default gui class
+     */
+    @SideOnly(Side.CLIENT)
+    public abstract String getClientMessage();
+
+    /**
+     * Children MUST annotate with @SideOnly(Side.CLIENT)
+     * <p>
+     * Client-side you can choose to either supply a custom {@link com.gtnewhorizon.gtnhlib.api.gui.GuiConfirmationWCW}
+     * or the default one with a text message. To show a default
+     * {@link com.gtnewhorizon.gtnhlib.api.gui.GuiConfirmationWCW} return null.
+     *
+     * @return Gui to be used in the warning. null to use default.
+     */
+    @SideOnly(Side.CLIENT)
+    public abstract GuiConfirmationWCW getGui(StartupQuery startupQuery);
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/WorldConversionWarningManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/WorldConversionWarningManager.java
@@ -1,0 +1,27 @@
+package com.gtnewhorizon.gtnhlib.api.gui;
+
+import java.util.HashMap;
+
+import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
+
+/**
+ * Allows to register more confirmation screens to show before the FML missing mapping warning screen. Specifically
+ * designed for world conversion warnings, these will only fire if the currently loading world contains any missing
+ * mapping. Fires *after* {@link cpw.mods.fml.common.event.FMLMissingMappingsEvent}s but *before* the warning gui /
+ * server message.
+ */
+@EventBusSubscriber
+public class WorldConversionWarningManager {
+
+    public static final HashMap<String, WorldConversionWarning> WARNINGS = new HashMap<>();
+
+    /**
+     * Call during game startup to register a {@link WorldConversionWarning}.
+     *
+     * @param id A unique id for your warning
+     */
+    public static void register(String id, WorldConversionWarning wcw) {
+        WARNINGS.put(id, wcw);
+    }
+
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/WorldConversionWarningManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/WorldConversionWarningManager.java
@@ -2,15 +2,12 @@ package com.gtnewhorizon.gtnhlib.api.gui;
 
 import java.util.HashMap;
 
-import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
-
 /**
  * Allows to register more confirmation screens to show before the FML missing mapping warning screen. Specifically
  * designed for world conversion warnings, these will only fire if the currently loading world contains any missing
  * mapping. Fires *after* {@link cpw.mods.fml.common.event.FMLMissingMappingsEvent}s but *before* the warning gui /
  * server message.
  */
-@EventBusSubscriber
 public class WorldConversionWarningManager {
 
     public static final HashMap<String, WorldConversionWarning> WARNINGS = new HashMap<>();

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/WorldConversionWarningManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/gui/WorldConversionWarningManager.java
@@ -10,14 +10,14 @@ import java.util.HashMap;
  */
 public class WorldConversionWarningManager {
 
-    public static final HashMap<String, WorldConversionWarning> WARNINGS = new HashMap<>();
+    public static final HashMap<String, IWorldConversionWarning> WARNINGS = new HashMap<>();
 
     /**
-     * Call during game startup to register a {@link WorldConversionWarning}.
+     * Call during game startup to register a {@link IWorldConversionWarning}.
      *
      * @param id A unique id for your warning
      */
-    public static void register(String id, WorldConversionWarning wcw) {
+    public static void register(String id, IWorldConversionWarning wcw) {
         WARNINGS.put(id, wcw);
     }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventhandlers/ClientEventHandler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventhandlers/ClientEventHandler.java
@@ -1,0 +1,40 @@
+package com.gtnewhorizon.gtnhlib.eventhandlers;
+
+import net.minecraftforge.client.event.GuiOpenEvent;
+
+import com.gtnewhorizon.gtnhlib.api.gui.GuiConfirmationWCW;
+import com.gtnewhorizon.gtnhlib.api.gui.WorldConversionWarningManager;
+import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
+import com.gtnewhorizon.gtnhlib.mixins.early.AccessorGuiNotification;
+import com.gtnewhorizon.gtnhlib.mixins.early.AccessorStartupQuery;
+
+import cpw.mods.fml.client.GuiConfirmation;
+import cpw.mods.fml.common.StartupQuery;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+@EventBusSubscriber
+public class ClientEventHandler {
+
+    @SubscribeEvent
+    public static void onGuiOpen(GuiOpenEvent event) {
+        if (!(event.gui instanceof GuiConfirmation confirmationGui)) return;
+
+        StartupQuery query = ((AccessorGuiNotification) confirmationGui).gtnhlib$getQuery();
+
+        WorldConversionWarningManager.WARNINGS.forEach((id, wcw) -> {
+            if (query.getText().equals(id)) {
+                ((AccessorStartupQuery) query).gtnhlib$setText(wcw.getClientMessage());
+                GuiConfirmationWCW gui = wcw.getGui(query);
+
+                if (gui != null) {
+                    event.gui = gui;
+                } else {
+                    event.gui = new GuiConfirmationWCW(query);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventhandlers/ClientEventHandler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventhandlers/ClientEventHandler.java
@@ -18,6 +18,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 @EventBusSubscriber
 public class ClientEventHandler {
 
+    // Put here because WorldConversionWarningManager is common and cannot try to import gui classes
     @SubscribeEvent
     public static void onGuiOpen(GuiOpenEvent event) {
         if (!(event.gui instanceof GuiConfirmation confirmationGui)) return;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -59,7 +59,9 @@ public enum Mixins implements IMixins {
                     .setPhase(Phase.LATE).addCommonMixins("MixinEnhancedInfusionRecipe")
                     .addRequiredMod(TargetMods.THAUMCRAFT)),
     CONFIG_ORDER(Side.CLIENT, "fml.MixinGuiConfig"),
-    WORLD_DELETION_EVENT(Side.CLIENT, "MixinGuiSelectWorld")
+    WORLD_DELETION_EVENT(Side.CLIENT, "MixinGuiSelectWorld"),
+    WORLD_LOAD_WARNING(new MixinBuilder("Accessors for the world conversion warning screen system")
+            .addCommonMixins("AccessorGuiNotification", "AccessorStartupQuery").setPhase(Phase.EARLY)),
     //
     ;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/PreInitMixinPlugin.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/PreInitMixinPlugin.java
@@ -1,0 +1,49 @@
+package com.gtnewhorizon.gtnhlib.mixins;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.spongepowered.asm.lib.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+public class PreInitMixinPlugin implements IMixinConfigPlugin {
+
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return "";
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+    @Override
+    public List<String> getMixins() {
+        List<String> mixins = new ArrayList<>();
+
+        mixins.add("MixinGameData_WorldConversionWarning");
+
+        return mixins;
+    }
+
+    @Override
+    public void preApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {
+
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/AccessorGuiNotification.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/AccessorGuiNotification.java
@@ -1,0 +1,14 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import cpw.mods.fml.client.GuiNotification;
+import cpw.mods.fml.common.StartupQuery;
+
+@Mixin(GuiNotification.class)
+public interface AccessorGuiNotification {
+
+    @Accessor(value = "query", remap = false)
+    StartupQuery gtnhlib$getQuery();
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/AccessorStartupQuery.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/AccessorStartupQuery.java
@@ -1,0 +1,13 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import cpw.mods.fml.common.StartupQuery;
+
+@Mixin(StartupQuery.class)
+public interface AccessorStartupQuery {
+
+    @Accessor(value = "text", remap = false)
+    void gtnhlib$setText(String text);
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/preinit/MixinGameData_WorldConversionWarning.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/preinit/MixinGameData_WorldConversionWarning.java
@@ -1,0 +1,44 @@
+package com.gtnewhorizon.gtnhlib.mixins.preinit;
+
+import java.util.List;
+import java.util.Map;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.gtnewhorizon.gtnhlib.api.gui.WorldConversionWarningManager;
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.StartupQuery;
+import cpw.mods.fml.common.event.FMLMissingMappingsEvent;
+import cpw.mods.fml.common.registry.GameData;
+
+@Mixin(GameData.class)
+public class MixinGameData_WorldConversionWarning {
+
+    // This pre-init mixin is required to inject into the exact moment after missing mapping events are fired
+    // but before the confirmation message appears.
+    @Definition(id = "defaulted", local = @Local(type = List.class, name = "defaulted"))
+    @Definition(id = "isEmpty", method = "Ljava/util/List;isEmpty()Z")
+    @Expression("defaulted.isEmpty()")
+    @Inject(
+            method = "processIdRematches",
+            at = @At(value = "MIXINEXTRAS:EXPRESSION", shift = At.Shift.BY, by = -2),
+            remap = false)
+    private static void uie$processIdRematches(Iterable<FMLMissingMappingsEvent.MissingMapping> missedMappings,
+            boolean isLocalWorld, GameData gameData, Map<String, Integer[]> remaps,
+            CallbackInfoReturnable<List<String>> cir) {
+        WorldConversionWarningManager.WARNINGS.forEach((id, wcw) -> {
+            if (wcw.shouldShow()) {
+                boolean confirmed = StartupQuery
+                        .confirm(FMLCommonHandler.instance().getSide().isServer() ? wcw.getServerMessage() : id);
+                if (!confirmed) StartupQuery.abort();
+            }
+        });
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/preinit/MixinGameData_WorldConversionWarning.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/preinit/MixinGameData_WorldConversionWarning.java
@@ -8,13 +8,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.gtnewhorizon.gtnhlib.api.gui.WorldConversionWarningManager;
+import com.gtnewhorizon.gtnhlib.api.gui.WCWHelper;
 import com.llamalad7.mixinextras.expression.Definition;
 import com.llamalad7.mixinextras.expression.Expression;
 import com.llamalad7.mixinextras.sugar.Local;
 
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.StartupQuery;
 import cpw.mods.fml.common.event.FMLMissingMappingsEvent;
 import cpw.mods.fml.common.registry.GameData;
 
@@ -30,15 +28,9 @@ public class MixinGameData_WorldConversionWarning {
             method = "processIdRematches",
             at = @At(value = "MIXINEXTRAS:EXPRESSION", shift = At.Shift.BY, by = -2),
             remap = false)
-    private static void uie$processIdRematches(Iterable<FMLMissingMappingsEvent.MissingMapping> missedMappings,
+    private static void gtnhlib$processIdRematches(Iterable<FMLMissingMappingsEvent.MissingMapping> missedMappings,
             boolean isLocalWorld, GameData gameData, Map<String, Integer[]> remaps,
             CallbackInfoReturnable<List<String>> cir) {
-        WorldConversionWarningManager.WARNINGS.forEach((id, wcw) -> {
-            if (wcw.shouldShow()) {
-                boolean confirmed = StartupQuery
-                        .confirm(FMLCommonHandler.instance().getSide().isServer() ? wcw.getServerMessage() : id);
-                if (!confirmed) StartupQuery.abort();
-            }
-        });
+        WCWHelper.fireWarnings();
     }
 }

--- a/src/main/resources/mixins.gtnhlib.preinit.json
+++ b/src/main/resources/mixins.gtnhlib.preinit.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "minVersion": "0.8.5-GTNH",
+  "refmap": "mixins.gtnhlib.refmap.json",
+  "target": "@env(PREINIT)",
+  "mixinextras": {
+    "minVersion": "0.5.0"
+  },
+  "compatibilityLevel": "JAVA_8",
+  "plugin": "com.gtnewhorizon.gtnhlib.mixins.PreInitMixinPlugin",
+  "package": "com.gtnewhorizon.gtnhlib.mixins.preinit"
+}


### PR DESCRIPTION
This is a simple system for showing custom warning screens when trying to load a world where items and blocks need to be converted from one mod to another

<img width="841" height="473" alt="image" src="https://github.com/user-attachments/assets/76a63253-4846-4f29-8394-e493f5a14324" />
