### PR TITLE
Port ResourceUtils from GT5U to NHlib

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
@@ -2,12 +2,15 @@ package com.gtnewhorizon.gtnhlib;
 
 import static com.gtnewhorizon.gtnhlib.GTNHLib.MODID;
 
+import com.gtnewhorizon.gtnhlib.util.ResourceUtil;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.SimpleReloadableResourceManager;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 import net.minecraftforge.client.ClientCommandHandler;
+import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.common.MinecraftForge;
 
 import com.gtnewhorizon.gtnhlib.client.ResourcePackUpdater.ResourcePackUpdateEventHandler;
@@ -101,6 +104,11 @@ public class ClientProxy extends CommonProxy {
         resourceManager.registerReloadListener(new ModelRegistry.ReloadListener());
         resourceManager.registerReloadListener(new ColorResource.CacheReloadListener());
         MinecraftForge.EVENT_BUS.register(new ModelRegistry.EventHandler());
+    }
+
+    @SubscribeEvent
+    public void onFinishTextureStitch(TextureStitchEvent.Post event) {
+        ResourceUtil.clearCache();
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
@@ -2,8 +2,6 @@ package com.gtnewhorizon.gtnhlib;
 
 import static com.gtnewhorizon.gtnhlib.GTNHLib.MODID;
 
-import com.gtnewhorizon.gtnhlib.util.ResourceUtil;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.SimpleReloadableResourceManager;
 import net.minecraft.util.ChatComponentText;
@@ -30,6 +28,7 @@ import com.gtnewhorizon.gtnhlib.eventhandlers.ConfigEventHandler;
 import com.gtnewhorizon.gtnhlib.itemrendering.TexturedItemRenderer;
 import com.gtnewhorizon.gtnhlib.test.item.TestItem;
 import com.gtnewhorizon.gtnhlib.util.AboveHotbarHUD;
+import com.gtnewhorizon.gtnhlib.util.ResourceUtil;
 
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -37,6 +36,7 @@ import cpw.mods.fml.common.event.FMLConstructionEvent;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.relauncher.Side;
 import lombok.Getter;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/ResourceUtil.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/ResourceUtil.java
@@ -1,0 +1,101 @@
+package com.gtnewhorizon.gtnhlib.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.FallbackResourceManager;
+import net.minecraft.client.resources.IResource;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.IResourcePack;
+import net.minecraft.client.resources.SimpleReloadableResourceManager;
+import net.minecraft.util.ResourceLocation;
+
+import org.jetbrains.annotations.NotNull;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
+
+public class ResourceUtil {
+
+    // 14810 (max size GT5 as of 2026/29/5) * 1.333 = 19.7k ~= 20k
+    private static final int EXISTS_CACHE_SIZE = 20_000;
+    private static Object2BooleanOpenHashMap<ResourceLocation> EXISTS_CACHE = new Object2BooleanOpenHashMap<>(
+            EXISTS_CACHE_SIZE);
+
+    /**
+     * Checks whether a resource exists.
+     *
+     * @param resLoc the {@link ResourceLocation} identifying the resource to check
+     * @return {@code true} if the resource exists; {@code false} otherwise
+     */
+    @SideOnly(Side.CLIENT)
+    public static boolean resourceExists(@NotNull ResourceLocation resLoc) {
+        return EXISTS_CACHE.computeIfAbsent(resLoc, ResourceUtil::checkResource);
+    }
+
+    @SideOnly(Side.CLIENT)
+    private static boolean checkResource(@NotNull ResourceLocation resLoc) {
+        final IResourceManager resMan = Minecraft.getMinecraft().getResourceManager();
+        if (resMan instanceof SimpleReloadableResourceManager simple) {
+            FallbackResourceManager fallback = simple.domainResourceManagers.get(resLoc.getResourceDomain());
+            if (fallback != null) {
+                for (IResourcePack rp : fallback.resourcePacks) {
+                    if (rp != null && rp.resourceExists(resLoc)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        // Fallback in case some mod changed how the resource manager stores ResourcePacks
+        IResource res = null;
+        try {
+            res = resMan.getResource(resLoc);
+            return true;
+        } catch (IOException ignored) {
+            return false;
+        } finally {
+            if (res != null) {
+                try {
+                    InputStream stream = res.getInputStream();
+                    if (stream != null) {
+                        stream.close();
+                    }
+                } catch (IOException ignored) {}
+            }
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void clearCache() {
+        EXISTS_CACHE = new Object2BooleanOpenHashMap<>(EXISTS_CACHE_SIZE);
+    }
+
+    /**
+     * Get the complete resource location from the short local resource location key.
+     *
+     * @param basePath    The base path for the resource (e.g.: textures/blocks/)
+     * @param ext         The file name extension of the resource (e.g.: .png)
+     * @param resourceKey The local resource location key (without textures/blocks|items and without the filename
+     *                    extension)
+     * @return The complete ResourceLocation pointing to the resource file
+     */
+    public static @NotNull ResourceLocation getCompleteResourceLocation(@NotNull String basePath, @NotNull String ext,
+            @NotNull String resourceKey) {
+        final int i = resourceKey.indexOf(':');
+        final String domain = (i <= 0) ? "" : resourceKey.substring(0, i);
+        final String path = (i < 0) ? resourceKey : resourceKey.substring(i + 1);
+        return new ResourceLocation(domain, basePath + path + ext);
+    }
+
+    public static @NotNull ResourceLocation getCompleteBlockTextureResourceLocation(@NotNull String resourceKey) {
+        return getCompleteResourceLocation("textures/blocks/", ".png", resourceKey);
+    }
+
+    public static @NotNull ResourceLocation getCompleteItemTextureResourceLocation(String resourceKey) {
+        return getCompleteResourceLocation("textures/items/", ".png", resourceKey);
+    }
+}

--- a/src/main/resources/META-INF/gtnhlib_at.cfg
+++ b/src/main/resources/META-INF/gtnhlib_at.cfg
@@ -27,3 +27,5 @@ public net.minecraft.util.RegistrySimple field_82596_a # registryObjects
 public net.minecraft.nbt.NBTTagCompound field_74784_a # tagMap
 public net.minecraft.nbt.NBTTagList field_74747_a # tagList
 public net.minecraft.entity.Entity field_70148_d # firstUpdate
+public net.minecraft.client.resources.SimpleReloadableResourceManager field_110548_a # domainResourceManagers
+public net.minecraft.client.resources.FallbackResourceManager field_110540_a # resourcePacks


### PR DESCRIPTION
## Summary
This is a useful and general utility that I think makes sense to have here instead of within GT5-U. This is just a direct copy-paste, and does nothing on its own. Should be safe for freeze (the GT5-U conversion to use this one instead, less appropriate for freeze).


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
