### PR TITLE
Fix NumberPattern

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonPrimitive;
 // Taken from NEI
 public class NBTJson {
 
-    private static final Pattern numberPattern = Pattern.compile("^([-+]?\\d+\\.?\\d*E*\\d*)([bBsSlLfFdD]?)$");
+    private static final Pattern numberPattern = Pattern.compile("^([-+]?\\d+\\.?\\d*E*\\d{,20)([bBsSlLfFdD]?)$");
 
     public static String toJson(NBTTagCompound tag) {
         return toJson(toJsonObject(tag));
@@ -153,7 +153,8 @@ public class NBTJson {
                     }
                 } else {
                     if (numberString.contains(".")) return new NBTTagDouble(Double.parseDouble(numberString));
-                    else return new NBTTagInt(Integer.parseInt(numberString));
+                    else if (numberString.length() <= 12) return new NBTTagInt(Integer.parseInt(numberString));
+                    else return new NBTTagString(jsonString);
                 }
             } else {
                 // String

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
@@ -32,7 +32,7 @@ public class NBTJson {
             .compile("^([-+]?\\d{1,20}(?:\\.?\\d*(?:[eE][-+]?\\d+)?)?)([bBsSlLfFdD]?)$");
     /**
      * in case someone actually puts a "+" signed unsigned int into a json
-     * 
+     *
      * @see Integer#parseUnsignedInt(String)
      */
     private static final int UNSIGNED_INT_STRING_LENGTH = 12;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonPrimitive;
 // Taken from NEI
 public class NBTJson {
 
-    private static final Pattern numberPattern = Pattern.compile("^([-+]?\\d{1,20}(?:\\.\\d*[eE][-+]?\\d+)?)([bBsSlLfFdD]?)$");
+    private static final Pattern numberPattern = Pattern.compile("^([-+]?\\d{1,20}(?:\\.?\\d*(?:[eE][-+]?\\d+)?)?)([bBsSlLfFdD]?)$");
     /**
      * in case someone actually puts a "+" signed unsigned int into a json
      * 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
@@ -29,7 +29,7 @@ import com.google.gson.JsonPrimitive;
 public class NBTJson {
 
     private static final Pattern numberPattern = Pattern
-            .compile("^([-+]?\\d{1,20}(?:\\.?\\d*(?:[eE][-+]?\\d+)?)?)([bBsSlLfFdD]?)$");
+            .compile("^([-+]?\\d{1,20}(?:\\.?\\d+(?:[eE][-+]?\\d+)?)?)([bBsSlLfFdD]?)$");
     /**
      * in case someone actually puts a "+" signed unsigned int into a json
      *
@@ -47,14 +47,13 @@ public class NBTJson {
 
     @SuppressWarnings("unchecked")
     public static JsonElement toJsonObject(NBTBase nbt) {
-        if (nbt instanceof NBTTagCompound) {
+        if (nbt instanceof NBTTagCompound nbtTagCompound) {
             // NBTTagCompound
-            final NBTTagCompound nbtTagCompound = (NBTTagCompound) nbt;
             final Map<String, NBTBase> tagMap = (Map<String, NBTBase>) nbtTagCompound.tagMap;
             final JsonObject root = new JsonObject();
 
             tagMap.entrySet().stream().sorted(Map.Entry.<String, NBTBase>comparingByKey())
-                    .forEach(nbtEntry -> { root.add(nbtEntry.getKey(), toJsonObject(nbtEntry.getValue())); });
+                    .forEach(nbtEntry -> root.add(nbtEntry.getKey(), toJsonObject(nbtEntry.getValue())));
 
             return root;
         } else if (nbt instanceof NBTTagByte) {
@@ -81,9 +80,8 @@ public class NBTJson {
         } else if (nbt instanceof NBTTagString) {
             // String
             return new JsonPrimitive(((NBTTagString) nbt).func_150285_a_());
-        } else if (nbt instanceof NBTTagList) {
+        } else if (nbt instanceof NBTTagList list) {
             // Tag List
-            final NBTTagList list = (NBTTagList) nbt;
 
             if (list.tagList.isEmpty()) {
                 return createEmptyList(list);
@@ -93,9 +91,8 @@ public class NBTJson {
                 return arr;
             }
 
-        } else if (nbt instanceof NBTTagIntArray) {
+        } else if (nbt instanceof NBTTagIntArray list) {
             // Int Array
-            final NBTTagIntArray list = (NBTTagIntArray) nbt;
 
             if (list.func_150302_c().length == 0) {
                 return createEmptyList(list);
@@ -109,9 +106,8 @@ public class NBTJson {
                 return arr;
             }
 
-        } else if (nbt instanceof NBTTagByteArray) {
+        } else if (nbt instanceof NBTTagByteArray list) {
             // Byte Array
-            final NBTTagByteArray list = (NBTTagByteArray) nbt;
 
             if (list.func_150292_c().length == 0) {
                 return createEmptyList(list);
@@ -131,9 +127,8 @@ public class NBTJson {
     }
 
     public static NBTBase toNbt(JsonElement jsonElement) {
-        if (jsonElement instanceof JsonPrimitive) {
+        if (jsonElement instanceof JsonPrimitive jsonPrimitive) {
             // Number or String
-            final JsonPrimitive jsonPrimitive = (JsonPrimitive) jsonElement;
             final String jsonString = jsonPrimitive.getAsString();
             final Matcher m = numberPattern.matcher(jsonString);
             if (m.matches()) {
@@ -170,9 +165,8 @@ public class NBTJson {
                 // String
                 return new NBTTagString(jsonString);
             }
-        } else if (jsonElement instanceof JsonArray) {
+        } else if (jsonElement instanceof JsonArray jsonArray) {
             // NBTTagIntArray or NBTTagList
-            final JsonArray jsonArray = (JsonArray) jsonElement;
             final List<NBTBase> nbtList = new ArrayList<>();
 
             for (JsonElement element : jsonArray) {
@@ -195,9 +189,8 @@ public class NBTJson {
 
                 return nbtTagList;
             }
-        } else if (jsonElement instanceof JsonObject) {
+        } else if (jsonElement instanceof JsonObject jsonObject) {
             // NBTTagCompound
-            final JsonObject jsonObject = (JsonObject) jsonElement;
             final NBTBase custom = restoreEmptyList(jsonObject);
 
             if (custom == null) {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
@@ -136,10 +136,10 @@ public class NBTJson {
             final JsonPrimitive jsonPrimitive = (JsonPrimitive) jsonElement;
             final String jsonString = jsonPrimitive.getAsString();
             final Matcher m = numberPattern.matcher(jsonString);
-            if (m.find()) {
+            if (m.matches()) {
                 // Number
                 final String numberString = m.group(1);
-                if (m.groupCount() == 2 && m.group(2).length() > 0) {
+                if (m.groupCount() == 2 && !m.group(2).isEmpty()) {
                     final char numberType = m.group(2).charAt(0);
                     switch (numberType) {
                         case 'b':
@@ -159,8 +159,7 @@ public class NBTJson {
                             return new NBTTagDouble(Double.parseDouble(numberString));
                     }
                 } else {
-                    if (numberString.indexOf('.') >= 0
-                            || numberString.indexOf('e') >= 0
+                    if (numberString.indexOf('.') >= 0 || numberString.indexOf('e') >= 0
                             || numberString.indexOf('E') >= 0)
                         return new NBTTagDouble(Double.parseDouble(numberString));
                     else if (numberString.length() <= UNSIGNED_INT_STRING_LENGTH)

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
@@ -28,13 +28,14 @@ import com.google.gson.JsonPrimitive;
 // Taken from NEI
 public class NBTJson {
 
-    private static final Pattern numberPattern = Pattern.compile("^([-+]?\\d{1,20}(?:\\.?\\d*(?:[eE][-+]?\\d+)?)?)([bBsSlLfFdD]?)$");
+    private static final Pattern numberPattern = Pattern
+            .compile("^([-+]?\\d{1,20}(?:\\.?\\d*(?:[eE][-+]?\\d+)?)?)([bBsSlLfFdD]?)$");
     /**
      * in case someone actually puts a "+" signed unsigned int into a json
      * 
      * @see Integer#parseUnsignedInt(String)
      */
-    private static final int UNSIGNED_INT_STRING_LENGTH = 12; 
+    private static final int UNSIGNED_INT_STRING_LENGTH = 12;
 
     public static String toJson(NBTTagCompound tag) {
         return toJson(toJsonObject(tag));
@@ -159,7 +160,8 @@ public class NBTJson {
                     }
                 } else {
                     if (numberString.contains(".")) return new NBTTagDouble(Double.parseDouble(numberString));
-                    else if (numberString.length() <= UNSIGNED_INT_STRING_LENGTH) return new NBTTagInt(Integer.parseInt(numberString));
+                    else if (numberString.length() <= UNSIGNED_INT_STRING_LENGTH)
+                        return new NBTTagInt(Integer.parseInt(numberString));
                     else return new NBTTagString(jsonString);
                 }
             } else {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonPrimitive;
 // Taken from NEI
 public class NBTJson {
 
-    private static final Pattern numberPattern = Pattern.compile("^([-+]?\\d+\\.?\\d*E*\\d{,20)([bBsSlLfFdD]?)$");
+    private static final Pattern numberPattern = Pattern.compile("^([-+]?\\d{1,20}(?:\\.\\d*[eE][-+]?\\d+)?)([bBsSlLfFdD]?)$");
     /**
      * in case someone actually puts a "+" signed unsigned int into a json
      * 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
@@ -29,6 +29,12 @@ import com.google.gson.JsonPrimitive;
 public class NBTJson {
 
     private static final Pattern numberPattern = Pattern.compile("^([-+]?\\d+\\.?\\d*E*\\d{,20)([bBsSlLfFdD]?)$");
+    /**
+     * in case someone actually puts a "+" signed unsigned int into a json
+     * 
+     * @see Integer#parseUnsignedInt(String)
+     */
+    private static final int UNSIGNED_INT_STRING_LENGTH = 12; 
 
     public static String toJson(NBTTagCompound tag) {
         return toJson(toJsonObject(tag));
@@ -153,7 +159,7 @@ public class NBTJson {
                     }
                 } else {
                     if (numberString.contains(".")) return new NBTTagDouble(Double.parseDouble(numberString));
-                    else if (numberString.length() <= 12) return new NBTTagInt(Integer.parseInt(numberString));
+                    else if (numberString.length() <= UNSIGNED_INT_STRING_LENGTH) return new NBTTagInt(Integer.parseInt(numberString));
                     else return new NBTTagString(jsonString);
                 }
             } else {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/NBTJson.java
@@ -159,7 +159,10 @@ public class NBTJson {
                             return new NBTTagDouble(Double.parseDouble(numberString));
                     }
                 } else {
-                    if (numberString.contains(".")) return new NBTTagDouble(Double.parseDouble(numberString));
+                    if (numberString.indexOf('.') >= 0
+                            || numberString.indexOf('e') >= 0
+                            || numberString.indexOf('E') >= 0)
+                        return new NBTTagDouble(Double.parseDouble(numberString));
                     else if (numberString.length() <= UNSIGNED_INT_STRING_LENGTH)
                         return new NBTTagInt(Integer.parseInt(numberString));
                     else return new NBTTagString(jsonString);


### PR DESCRIPTION
## Summary
Fixes the regex for numbers, it was inprecisely capturing a lot of invalid notations for 8-64bit integers & captured integers above 64bit.

Tested values:
000000
-0000000
-11111
111111
1.
-2.9
2.9
+2.9
1e1
1.e1
1e-1
-1e8
+8e4
-2374623.233525e+23423

invalid values:
1e   missing at least 1 digit for exponent
digits of integers as strings longer than 20 chars

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
