### PR TITLE
Make onFinishTextureStitch static to fix client init crash

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/ClientProxy.java
@@ -107,7 +107,7 @@ public class ClientProxy extends CommonProxy {
     }
 
     @SubscribeEvent
-    public void onFinishTextureStitch(TextureStitchEvent.Post event) {
+    public static void onFinishTextureStitch(TextureStitchEvent.Post event) {
         ResourceUtil.clearCache();
     }
 


### PR DESCRIPTION
## Summary
Fixes #419
Caused by #416 

Someone didn't even try to run client once 😠 

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
