### PR TITLE
Add bukkit compatibility Layer

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
@@ -130,8 +130,20 @@ public class CommonProxy {
         event.registerServerCommand(new BlockStateCommand());
         event.registerServerCommand(new TitleCommand());
 
-        for (CommandNode<ICommandSender> node : BrigadierApi.getCommandDispatcher().getRoot().getChildren()) {
-            event.registerServerCommand(new BrigadierCommandWrapper(node.getName()));
+        if (isThermosServer()) {
+            for (CommandNode<ICommandSender> node : BrigadierApi.getCommandDispatcher().getRoot().getChildren()) {
+                event.registerServerCommand(new BrigadierCommandWrapper(node.getName()));
+            }
+        }
+    }
+
+    public static boolean isThermosServer() {
+        try {
+            Class.forName("thermos.ThermosRemapper");
+            GTNHLib.LOG.warn("Thermos detected, applying command wrapper");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
         }
     }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
@@ -140,7 +140,7 @@ public class CommonProxy {
     public static boolean isThermosServer() {
         try {
             Class.forName("thermos.ThermosRemapper");
-            GTNHLib.LOG.warn("Thermos detected, applying command wrapper");
+            GTNHLib.LOG.info("Thermos detected, applying command wrapper");
             return true;
         } catch (ClassNotFoundException e) {
             return false;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
@@ -137,9 +137,14 @@ public class CommonProxy {
         }
     }
 
+    /**
+     * Checks if the current environment is a Thermos server or its fork like Crucible.
+     *
+     * @return true if the server core is detected, false otherwise.
+     */
     public static boolean isThermosServer() {
         try {
-            Class.forName("thermos.ThermosRemapper");
+            Class.forName("thermos.ThermosRemapper", false, CommonProxy.class.getClassLoader());
             GTNHLib.LOG.info("Thermos detected, applying command wrapper");
             return true;
         } catch (ClassNotFoundException e) {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
@@ -2,6 +2,7 @@ package com.gtnewhorizon.gtnhlib;
 
 import static com.gtnewhorizon.gtnhlib.core.GTNHLibCore.isObf;
 
+import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraft.server.MinecraftServer;
@@ -12,6 +13,7 @@ import net.minecraftforge.common.util.FakePlayer;
 import com.gtnewhorizon.gtnhlib.blockstate.command.BlockStateCommand;
 import com.gtnewhorizon.gtnhlib.blockstate.init.BlockPropertyInit;
 import com.gtnewhorizon.gtnhlib.brigadier.BrigadierApi;
+import com.gtnewhorizon.gtnhlib.brigadier.BrigadierCommandWrapper;
 import com.gtnewhorizon.gtnhlib.chat.ChatComponentCustomRegistry;
 import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentEnergy;
 import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentFluid;
@@ -40,6 +42,7 @@ import com.gtnewhorizon.gtnhlib.test.block.BlockWeightedRngTest;
 import com.gtnewhorizon.gtnhlib.test.item.TestItem;
 import com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatConfig;
 import com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil;
+import com.mojang.brigadier.tree.CommandNode;
 
 import cpw.mods.fml.common.event.FMLConstructionEvent;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
@@ -126,6 +129,10 @@ public class CommonProxy {
     public void serverStarting(FMLServerStartingEvent event) {
         event.registerServerCommand(new BlockStateCommand());
         event.registerServerCommand(new TitleCommand());
+
+        for (CommandNode<ICommandSender> node : BrigadierApi.getCommandDispatcher().getRoot().getChildren()) {
+            event.registerServerCommand(new BrigadierCommandWrapper(node.getName()));
+        }
     }
 
     public void serverStarted(FMLServerStartedEvent event) {}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/brigadier/BrigadierCommandWrapper.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/brigadier/BrigadierCommandWrapper.java
@@ -1,0 +1,56 @@
+package com.gtnewhorizon.gtnhlib.brigadier;
+
+import java.util.List;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+
+import com.mojang.brigadier.tree.CommandNode;
+
+public class BrigadierCommandWrapper extends CommandBase {
+
+    private final String name;
+
+    public BrigadierCommandWrapper(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getCommandName() {
+        return this.name;
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/" + this.name;
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        CommandNode<ICommandSender> node = BrigadierApi.getCommandDispatcher().getRoot().getChild(this.name);
+        return node == null || node.canUse(sender);
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        StringBuilder command = new StringBuilder(this.name);
+        for (String arg : args) {
+            command.append(" ").append(arg);
+        }
+        BrigadierApi.executeCommand(sender, command.toString());
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        StringBuilder command = new StringBuilder(this.name);
+        for (String arg : args) {
+            command.append(" ").append(arg);
+        }
+        return BrigadierApi.getPossibleCommands(sender, command.toString());
+    }
+}


### PR DESCRIPTION
## Summary
Brigadier is incompatible with bukkit command registry. None of the commands registered by brigadierAPI would work on Thermos.
This compatibility Layer will register brigadier commands as standard commands **only on thermos server**.
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25797
Tested on a latest Crucible core server with daily 597.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
