### PR TITLE
Port 2d & 3d maps & sets from CC

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/blockpos/IBlockPos.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/blockpos/IBlockPos.java
@@ -2,9 +2,10 @@ package com.gtnewhorizon.gtnhlib.blockpos;
 
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.gtnewhorizon.gtnhlib.space.XYZAddressable;
 import com.gtnewhorizon.gtnhlib.util.CoordinatePacker;
 
-public interface IBlockPos {
+public interface IBlockPos extends XYZAddressable {
 
     int getX();
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashMap2D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashMap2D.java
@@ -4,6 +4,7 @@ import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker2D.packChunk;
 import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker2D.unpackChunkX;
 import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker2D.unpackChunkZ;
 
+import java.util.Iterator;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.BiFunction;
@@ -208,10 +209,16 @@ public class HashMap2D<V> extends Long2ObjectOpenHashMap<V> {
         return () -> fastEntrySet().fastIterator();
     }
 
-    public Stream<Entry2D<V>> fastEntryStream() {
+    /// Unlike {@link #fastEntryIterable()}, each returned {@link Entry2D} is an independent instance, so the result
+    /// is safe to buffer (e.g. via {@link Stream#sorted()} or {@link Stream#toList()}).
+    public Iterator<Entry2D<V>> slowIterator() {
+        return fastEntrySet().iterator();
+    }
+
+    public Stream<Entry2D<V>> slowStream() {
         return StreamSupport.stream(
                 Spliterators.spliterator(
-                        fastEntryIterable().iterator(),
+                        slowIterator(),
                         size(),
                         Spliterator.SIZED | Spliterator.NONNULL | Spliterator.DISTINCT),
                 false);

--- a/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashMap2D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashMap2D.java
@@ -1,0 +1,312 @@
+package com.gtnewhorizon.gtnhlib.datastructs.space;
+
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker2D.packChunk;
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker2D.unpackChunkX;
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker2D.unpackChunkZ;
+
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.gtnewhorizon.gtnhlib.functional.Compute2D;
+import com.gtnewhorizon.gtnhlib.functional.Compute2DWithValue;
+import com.gtnewhorizon.gtnhlib.functional.Consumer2DWithValue;
+import com.gtnewhorizon.gtnhlib.space.XZAddressable;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.AbstractObjectSet;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+
+@SuppressWarnings("unused")
+public class HashMap2D<V> extends Long2ObjectOpenHashMap<V> {
+
+    public V get(int posX, int posZ) {
+        return super.get(packChunk(posX, posZ));
+    }
+
+    public V get(XZAddressable xyz) {
+        return get(xyz.getX(), xyz.getZ());
+    }
+
+    public V remove(int posX, int posZ) {
+        return super.remove(packChunk(posX, posZ));
+    }
+
+    public V remove(XZAddressable xyz) {
+        return remove(xyz.getX(), xyz.getZ());
+    }
+
+    public boolean containsKey(int posX, int posZ) {
+        return super.containsKey(packChunk(posX, posZ));
+    }
+
+    public boolean containsKey(XZAddressable xyz) {
+        return containsKey(xyz.getX(), xyz.getZ());
+    }
+
+    public V put(int posX, int posZ, V v) {
+        return super.put(packChunk(posX, posZ), v);
+    }
+
+    public V put(XZAddressable xyz, V v) {
+        return put(xyz.getX(), xyz.getZ(), v);
+    }
+
+    public V computeIfAbsent(int posX, int posZ, @NotNull Compute2D<V> mappingFunction) {
+        V v;
+
+        long key = packChunk(posX, posZ);
+
+        if ((v = get(key)) == null) {
+            V newValue;
+            if ((newValue = mappingFunction.apply(posX, posZ)) != null) {
+                put(key, newValue);
+                return newValue;
+            }
+        }
+
+        return v;
+    }
+
+    public V computeIfAbsent(XZAddressable xyz, @NotNull Compute2D<V> mappingFunction) {
+        return computeIfAbsent(xyz.getX(), xyz.getZ(), mappingFunction);
+    }
+
+    public V compute(int posX, int posZ, @NotNull Compute2DWithValue<V> remappingFunction) {
+        return super.compute(packChunk(posX, posZ), (k, v) -> remappingFunction.apply(posX, posZ, v));
+    }
+
+    public V compute(XZAddressable xyz, @NotNull Compute2DWithValue<V> remappingFunction) {
+        return compute(xyz.getX(), xyz.getZ(), remappingFunction);
+    }
+
+    public V computeIfPresent(int posX, int posZ, @NotNull Compute2DWithValue<V> remappingFunction) {
+        return super.computeIfPresent(packChunk(posX, posZ), (k, v) -> remappingFunction.apply(posX, posZ, v));
+    }
+
+    public V computeIfPresent(XZAddressable xyz, @NotNull Compute2DWithValue<V> remappingFunction) {
+        return computeIfPresent(xyz.getX(), xyz.getZ(), remappingFunction);
+    }
+
+    public V getOrDefault(int posX, int posZ, V defaultValue) {
+        return super.getOrDefault(packChunk(posX, posZ), defaultValue);
+    }
+
+    public V getOrDefault(XZAddressable xyz, V defaultValue) {
+        return getOrDefault(xyz.getX(), xyz.getZ(), defaultValue);
+    }
+
+    /// Unlike [java.util.Map#putIfAbsent], a key already mapped to `null` is treated as present and will not be
+    /// overwritten.
+    public V putIfAbsent(int posX, int posZ, V v) {
+        return super.putIfAbsent(packChunk(posX, posZ), v);
+    }
+
+    public V putIfAbsent(XZAddressable xyz, V v) {
+        return putIfAbsent(xyz.getX(), xyz.getZ(), v);
+    }
+
+    public boolean remove(int posX, int posZ, V value) {
+        return super.remove(packChunk(posX, posZ), value);
+    }
+
+    public boolean remove(XZAddressable xyz, V value) {
+        return remove(xyz.getX(), xyz.getZ(), value);
+    }
+
+    public V replace(int posX, int posZ, V value) {
+        return super.replace(packChunk(posX, posZ), value);
+    }
+
+    public V replace(XZAddressable xyz, V value) {
+        return replace(xyz.getX(), xyz.getZ(), value);
+    }
+
+    public boolean replace(int posX, int posZ, V oldValue, V newValue) {
+        return super.replace(packChunk(posX, posZ), oldValue, newValue);
+    }
+
+    public boolean replace(XZAddressable xyz, V oldValue, V newValue) {
+        return replace(xyz.getX(), xyz.getZ(), oldValue, newValue);
+    }
+
+    public V merge(int posX, int posZ, @NotNull V value,
+            @NotNull BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        return super.merge(packChunk(posX, posZ), value, remappingFunction);
+    }
+
+    public V merge(XZAddressable xyz, @NotNull V value,
+            @NotNull BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        return merge(xyz.getX(), xyz.getZ(), value, remappingFunction);
+    }
+
+    public void forEach(Consumer2DWithValue<V> consumer) {
+        for (var e : this.fastEntryIterable()) {
+            consumer.accept(e.getX(), e.getZ(), e.getValue());
+        }
+    }
+
+    public void replaceAll(@NotNull Compute2DWithValue<V> function) {
+        var iter = Long2ObjectMaps.fastIterator(this);
+
+        while (iter.hasNext()) {
+            var e = iter.next();
+
+            V value = e.getValue();
+            V newValue = function.apply(unpackChunkX(e.getLongKey()), unpackChunkZ(e.getLongKey()), value);
+
+            if (newValue != value) {
+                e.setValue(newValue);
+            }
+        }
+    }
+
+    public interface FastEntrySet2D<V> extends ObjectSet<Entry2D<V>> {
+
+        /**
+         * Returns a fast iterator over this entry set; the iterator might return always the same entry instance,
+         * suitably mutated.
+         *
+         * @return a fast iterator over this entry set; the iterator might return always the same
+         *         {@link java.util.Map.Entry} instance, suitably mutated.
+         */
+        ObjectIterator<Entry2D<V>> fastIterator();
+
+        /**
+         * Iterates quickly over this entry set; the iteration might happen always on the same entry instance, suitably
+         * mutated.
+         *
+         * <p>
+         *
+         * This default implementation just delegates to {@link #forEach(Consumer)}.
+         *
+         * @param consumer a consumer that will by applied to the entries of this set; the entries might be represented
+         *                 by the same entry instance, suitably mutated.
+         * @since 8.1.0
+         */
+        default void fastForEach(final Consumer<? super Entry2D<V>> consumer) {
+            forEach(consumer);
+        }
+    }
+
+    private FastEntrySet2DImpl entrySet;
+
+    public FastEntrySet2D<V> fastEntrySet() {
+        if (entrySet == null) entrySet = new FastEntrySet2DImpl();
+
+        return entrySet;
+    }
+
+    public Iterable<Entry2D<V>> fastEntryIterable() {
+        return () -> fastEntrySet().fastIterator();
+    }
+
+    public Stream<Entry2D<V>> fastEntryStream() {
+        return StreamSupport.stream(
+                Spliterators.spliterator(
+                        fastEntryIterable().iterator(),
+                        size(),
+                        Spliterator.SIZED | Spliterator.NONNULL | Spliterator.DISTINCT),
+                false);
+    }
+
+    private class FastEntrySet2DImpl extends AbstractObjectSet<Entry2D<V>> implements FastEntrySet2D<V> {
+
+        @Override
+        public ObjectIterator<Entry2D<V>> fastIterator() {
+            Entry2D<V> entry = new Entry2D<>();
+
+            var iter = HashMap2D.this.long2ObjectEntrySet().fastIterator();
+
+            return new ObjectIterator<>() {
+
+                @Override
+                public boolean hasNext() {
+                    return iter.hasNext();
+                }
+
+                @Override
+                public Entry2D<V> next() {
+                    var e = iter.next();
+
+                    entry.setKey(e.getLongKey());
+                    entry.setValue(e.getValue());
+
+                    return entry;
+                }
+            };
+        }
+
+        @Override
+        public @NotNull ObjectIterator<Entry2D<V>> iterator() {
+            var iter = HashMap2D.this.long2ObjectEntrySet().fastIterator();
+
+            return new ObjectIterator<>() {
+
+                @Override
+                public boolean hasNext() {
+                    return iter.hasNext();
+                }
+
+                @Override
+                public Entry2D<V> next() {
+                    var e = iter.next();
+
+                    return new Entry2D<>(e.getLongKey(), e.getValue());
+                }
+            };
+        }
+
+        @Override
+        public int size() {
+            return HashMap2D.this.size();
+        }
+    }
+
+    public static class Entry2D<T> extends BasicEntry<T> implements XZAddressable {
+
+        public Entry2D() {}
+
+        /// @deprecated Use [#Entry2D(long, Object)] to avoid the long boxing.
+        @Deprecated
+        public Entry2D(Long key, T value) {
+            super(key, value);
+        }
+
+        public Entry2D(long key, T value) {
+            super(key, value);
+        }
+
+        public Entry2D(int posX, int posZ, T value) {
+            super(packChunk(posX, posZ), value);
+        }
+
+        void setKey(long key) {
+            super.key = key;
+        }
+
+        @Override
+        public T setValue(T value) {
+            T old = super.value;
+            super.value = value;
+            return old;
+        }
+
+        @Override
+        public final int getX() {
+            return unpackChunkX(getLongKey());
+        }
+
+        @Override
+        public final int getZ() {
+            return unpackChunkZ(getLongKey());
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashMap3D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashMap3D.java
@@ -1,0 +1,316 @@
+package com.gtnewhorizon.gtnhlib.datastructs.space;
+
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.pack;
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackX;
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackY;
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackZ;
+
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.gtnewhorizon.gtnhlib.functional.Compute3D;
+import com.gtnewhorizon.gtnhlib.functional.Compute3DWithValue;
+import com.gtnewhorizon.gtnhlib.functional.Consumer3DWithValue;
+import com.gtnewhorizon.gtnhlib.space.XYZAddressable;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.AbstractObjectSet;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+
+@SuppressWarnings("unused")
+public class HashMap3D<V> extends Long2ObjectOpenHashMap<V> {
+
+    public V get(int posX, int posY, int posZ) {
+        return super.get(pack(posX, posY, posZ));
+    }
+
+    public V get(XYZAddressable xyz) {
+        return get(xyz.getX(), xyz.getY(), xyz.getZ());
+    }
+
+    public V remove(int posX, int posY, int posZ) {
+        return super.remove(pack(posX, posY, posZ));
+    }
+
+    public V remove(XYZAddressable xyz) {
+        return remove(xyz.getX(), xyz.getY(), xyz.getZ());
+    }
+
+    public boolean containsKey(int posX, int posY, int posZ) {
+        return super.containsKey(pack(posX, posY, posZ));
+    }
+
+    public boolean containsKey(XYZAddressable xyz) {
+        return containsKey(xyz.getX(), xyz.getY(), xyz.getZ());
+    }
+
+    public V put(int posX, int posY, int posZ, V v) {
+        return super.put(pack(posX, posY, posZ), v);
+    }
+
+    public V put(XYZAddressable xyz, V v) {
+        return put(xyz.getX(), xyz.getY(), xyz.getZ(), v);
+    }
+
+    public V computeIfAbsent(int posX, int posY, int posZ, @NotNull Compute3D<V> mappingFunction) {
+        V v;
+
+        long key = pack(posX, posY, posZ);
+
+        if ((v = get(key)) == null) {
+            V newValue;
+            if ((newValue = mappingFunction.apply(posX, posY, posZ)) != null) {
+                put(key, newValue);
+                return newValue;
+            }
+        }
+
+        return v;
+    }
+
+    public V computeIfAbsent(XYZAddressable xyz, @NotNull Compute3D<V> mappingFunction) {
+        return computeIfAbsent(xyz.getX(), xyz.getY(), xyz.getZ(), mappingFunction);
+    }
+
+    public V compute(int posX, int posY, int posZ, @NotNull Compute3DWithValue<V> remappingFunction) {
+        return super.compute(pack(posX, posY, posZ), (k, v) -> remappingFunction.apply(posX, posY, posZ, v));
+    }
+
+    public V compute(XYZAddressable xyz, @NotNull Compute3DWithValue<V> remappingFunction) {
+        return compute(xyz.getX(), xyz.getY(), xyz.getZ(), remappingFunction);
+    }
+
+    public V computeIfPresent(int posX, int posY, int posZ, @NotNull Compute3DWithValue<V> remappingFunction) {
+        return super.computeIfPresent(pack(posX, posY, posZ), (k, v) -> remappingFunction.apply(posX, posY, posZ, v));
+    }
+
+    public V computeIfPresent(XYZAddressable xyz, @NotNull Compute3DWithValue<V> remappingFunction) {
+        return computeIfPresent(xyz.getX(), xyz.getY(), xyz.getZ(), remappingFunction);
+    }
+
+    public V getOrDefault(int posX, int posY, int posZ, V defaultValue) {
+        return super.getOrDefault(pack(posX, posY, posZ), defaultValue);
+    }
+
+    public V getOrDefault(XYZAddressable xyz, V defaultValue) {
+        return getOrDefault(xyz.getX(), xyz.getY(), xyz.getZ(), defaultValue);
+    }
+
+    /// Unlike [java.util.Map#putIfAbsent], a key already mapped to `null` is treated as present and will not be
+    /// overwritten.
+    public V putIfAbsent(int posX, int posY, int posZ, V v) {
+        return super.putIfAbsent(pack(posX, posY, posZ), v);
+    }
+
+    public V putIfAbsent(XYZAddressable xyz, V v) {
+        return putIfAbsent(xyz.getX(), xyz.getY(), xyz.getZ(), v);
+    }
+
+    public boolean remove(int posX, int posY, int posZ, V value) {
+        return super.remove(pack(posX, posY, posZ), value);
+    }
+
+    public boolean remove(XYZAddressable xyz, V value) {
+        return remove(xyz.getX(), xyz.getY(), xyz.getZ(), value);
+    }
+
+    public V replace(int posX, int posY, int posZ, V value) {
+        return super.replace(pack(posX, posY, posZ), value);
+    }
+
+    public V replace(XYZAddressable xyz, V value) {
+        return replace(xyz.getX(), xyz.getY(), xyz.getZ(), value);
+    }
+
+    public boolean replace(int posX, int posY, int posZ, V oldValue, V newValue) {
+        return super.replace(pack(posX, posY, posZ), oldValue, newValue);
+    }
+
+    public boolean replace(XYZAddressable xyz, V oldValue, V newValue) {
+        return replace(xyz.getX(), xyz.getY(), xyz.getZ(), oldValue, newValue);
+    }
+
+    public V merge(int posX, int posY, int posZ, @NotNull V value,
+            @NotNull BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        return super.merge(pack(posX, posY, posZ), value, remappingFunction);
+    }
+
+    public V merge(XYZAddressable xyz, @NotNull V value,
+            @NotNull BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        return merge(xyz.getX(), xyz.getY(), xyz.getZ(), value, remappingFunction);
+    }
+
+    public void forEach(Consumer3DWithValue<V> consumer) {
+        for (var e : this.fastEntryIterable()) {
+            consumer.accept(e.getX(), e.getY(), e.getZ(), e.getValue());
+        }
+    }
+
+    public void replaceAll(@NotNull Compute3DWithValue<V> function) {
+        var iter = Long2ObjectMaps.fastIterator(this);
+
+        while (iter.hasNext()) {
+            var e = iter.next();
+
+            long key = e.getLongKey();
+            V value = e.getValue();
+            V newValue = function.apply(unpackX(key), unpackY(key), unpackZ(key), value);
+
+            if (newValue != value) {
+                e.setValue(newValue);
+            }
+        }
+    }
+
+    public interface FastEntrySet3D<V> extends ObjectSet<Entry3D<V>> {
+
+        /**
+         * Returns a fast iterator over this entry set; the iterator might return always the same entry instance,
+         * suitably mutated.
+         *
+         * @return a fast iterator over this entry set; the iterator might return always the same
+         *         {@link java.util.Map.Entry} instance, suitably mutated.
+         */
+        ObjectIterator<Entry3D<V>> fastIterator();
+
+        /**
+         * Iterates quickly over this entry set; the iteration might happen always on the same entry instance, suitably
+         * mutated.
+         *
+         * <p>
+         *
+         * This default implementation just delegates to {@link #forEach(Consumer)}.
+         *
+         * @param consumer a consumer that will by applied to the entries of this set; the entries might be represented
+         *                 by the same entry instance, suitably mutated.
+         * @since 8.1.0
+         */
+        default void fastForEach(final Consumer<? super Entry3D<V>> consumer) {
+            forEach(consumer);
+        }
+    }
+
+    private FastEntrySet3DImpl entrySet;
+
+    public FastEntrySet3D<V> fastEntrySet() {
+        if (entrySet == null) entrySet = new FastEntrySet3DImpl();
+
+        return entrySet;
+    }
+
+    public Iterable<Entry3D<V>> fastEntryIterable() {
+        return () -> fastEntrySet().fastIterator();
+    }
+
+    public Stream<Entry3D<V>> fastEntryStream() {
+        return StreamSupport.stream(
+                Spliterators.spliterator(
+                        fastEntryIterable().iterator(),
+                        size(),
+                        Spliterator.SIZED | Spliterator.NONNULL | Spliterator.DISTINCT),
+                false);
+    }
+
+    private class FastEntrySet3DImpl extends AbstractObjectSet<Entry3D<V>> implements FastEntrySet3D<V> {
+
+        @Override
+        public ObjectIterator<Entry3D<V>> fastIterator() {
+            Entry3D<V> entry = new Entry3D<>();
+
+            var iter = HashMap3D.this.long2ObjectEntrySet().fastIterator();
+
+            return new ObjectIterator<>() {
+
+                @Override
+                public boolean hasNext() {
+                    return iter.hasNext();
+                }
+
+                @Override
+                public Entry3D<V> next() {
+                    var e = iter.next();
+
+                    entry.setKey(e.getLongKey());
+                    entry.setValue(e.getValue());
+
+                    return entry;
+                }
+            };
+        }
+
+        @Override
+        public @NotNull ObjectIterator<Entry3D<V>> iterator() {
+            var iter = HashMap3D.this.long2ObjectEntrySet().fastIterator();
+
+            return new ObjectIterator<>() {
+
+                @Override
+                public boolean hasNext() {
+                    return iter.hasNext();
+                }
+
+                @Override
+                public Entry3D<V> next() {
+                    var e = iter.next();
+
+                    return new Entry3D<>(e.getLongKey(), e.getValue());
+                }
+            };
+        }
+
+        @Override
+        public int size() {
+            return HashMap3D.this.size();
+        }
+    }
+
+    public static class Entry3D<T> extends BasicEntry<T> implements XYZAddressable {
+
+        public Entry3D() {}
+
+        /// @deprecated Use [#Entry3D(long, Object)] to avoid the long boxing.
+        @Deprecated
+        public Entry3D(Long key, T value) {
+            super(key, value);
+        }
+
+        public Entry3D(long key, T value) {
+            super(key, value);
+        }
+
+        public Entry3D(int posX, int posY, int posZ, T value) {
+            super(pack(posX, posY, posZ), value);
+        }
+
+        void setKey(long key) {
+            super.key = key;
+        }
+
+        @Override
+        public T setValue(T value) {
+            T old = super.value;
+            super.value = value;
+            return old;
+        }
+
+        public final int getX() {
+            return unpackX(getLongKey());
+        }
+
+        public final int getY() {
+            return unpackY(getLongKey());
+        }
+
+        public final int getZ() {
+            return unpackZ(getLongKey());
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashMap3D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashMap3D.java
@@ -5,6 +5,7 @@ import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackX;
 import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackY;
 import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackZ;
 
+import java.util.Iterator;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.BiFunction;
@@ -210,10 +211,16 @@ public class HashMap3D<V> extends Long2ObjectOpenHashMap<V> {
         return () -> fastEntrySet().fastIterator();
     }
 
-    public Stream<Entry3D<V>> fastEntryStream() {
+    /// Unlike {@link #fastEntryIterable()}, each returned {@link Entry3D} is an independent instance, so the result
+    /// is safe to buffer (e.g. via {@link Stream#sorted()} or {@link Stream#toList()}).
+    public Iterator<Entry3D<V>> slowIterator() {
+        return fastEntrySet().iterator();
+    }
+
+    public Stream<Entry3D<V>> slowStream() {
         return StreamSupport.stream(
                 Spliterators.spliterator(
-                        fastEntryIterable().iterator(),
+                        slowIterator(),
                         size(),
                         Spliterator.SIZED | Spliterator.NONNULL | Spliterator.DISTINCT),
                 false);

--- a/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashSet2D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashSet2D.java
@@ -1,0 +1,92 @@
+package com.gtnewhorizon.gtnhlib.datastructs.space;
+
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker2D.packChunk;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.gtnewhorizon.gtnhlib.functional.Consumer2D;
+import com.gtnewhorizon.gtnhlib.space.MutableXZ;
+import com.gtnewhorizon.gtnhlib.space.XZAddressable;
+import com.gtnewhorizon.gtnhlib.util.CoordinatePacker2D;
+
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+
+@SuppressWarnings("unused")
+public class HashSet2D extends LongOpenHashSet {
+
+    public boolean contains(int posX, int posZ) {
+        return super.contains(packChunk(posX, posZ));
+    }
+
+    public boolean contains(XZAddressable xyz) {
+        return contains(xyz.getX(), xyz.getZ());
+    }
+
+    public boolean remove(int posX, int posZ) {
+        return super.remove(packChunk(posX, posZ));
+    }
+
+    public boolean remove(XZAddressable xyz) {
+        return remove(xyz.getX(), xyz.getZ());
+    }
+
+    public boolean add(int posX, int posZ) {
+        return super.add(packChunk(posX, posZ));
+    }
+
+    public boolean add(XZAddressable xyz) {
+        return add(xyz.getX(), xyz.getZ());
+    }
+
+    public void forEach(Consumer2D consumer) {
+        for (var e : this.fastEntryIterable()) {
+            consumer.accept(e.getX(), e.getZ());
+        }
+    }
+
+    /// The returned iterator always yields the same mutated {@link XZAddressable} instance; do not retain the
+    /// result of {@link Iterator#next()} past the following call.
+    public Iterator<XZAddressable> fastIterator() {
+        LongIterator iter = super.iterator();
+
+        MutableXZ pos = new MutableXZ();
+
+        return new Iterator<>() {
+
+            @Override
+            public boolean hasNext() {
+                return iter.hasNext();
+            }
+
+            @Override
+            public XZAddressable next() {
+                long l = iter.nextLong();
+
+                pos.x = CoordinatePacker2D.unpackChunkX(l);
+                pos.z = CoordinatePacker2D.unpackChunkZ(l);
+
+                return pos;
+            }
+        };
+    }
+
+    public Iterable<XZAddressable> fastEntryIterable() {
+        return this::fastIterator;
+    }
+
+    /// The stream elements are backed by the same mutated {@link XZAddressable} instance as
+    /// {@link #fastIterator()}; collect {@code new MutableXZ(e.getX(), e.getZ())} if you need to retain them.
+    public Stream<XZAddressable> fastEntryStream() {
+        return StreamSupport.stream(
+                Spliterators.spliterator(
+                        fastEntryIterable().iterator(),
+                        size(),
+                        Spliterator.SIZED | Spliterator.NONNULL | Spliterator.DISTINCT),
+                false);
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashSet2D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashSet2D.java
@@ -8,6 +8,8 @@ import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.jetbrains.annotations.Contract;
+
 import com.gtnewhorizon.gtnhlib.functional.Consumer2D;
 import com.gtnewhorizon.gtnhlib.space.MutableXZ;
 import com.gtnewhorizon.gtnhlib.space.XZAddressable;
@@ -49,6 +51,34 @@ public class HashSet2D extends LongOpenHashSet {
         }
     }
 
+    public Iterator<XZAddressable> slowIterator() {
+        LongIterator iter = super.iterator();
+
+        return new Iterator<>() {
+
+            @Contract(pure = true)
+            @Override
+            public boolean hasNext() {
+                return iter.hasNext();
+            }
+
+            @Contract(mutates = "this")
+            @Override
+            public XZAddressable next() {
+                return MutableXZ.unpack(iter.nextLong());
+            }
+        };
+    }
+
+    public Stream<XZAddressable> slowStream() {
+        return StreamSupport.stream(
+                Spliterators.spliterator(
+                        this.slowIterator(),
+                        size(),
+                        Spliterator.SIZED | Spliterator.NONNULL | Spliterator.DISTINCT),
+                false);
+    }
+
     /// The returned iterator always yields the same mutated {@link XZAddressable} instance; do not retain the
     /// result of {@link Iterator#next()} past the following call.
     public Iterator<XZAddressable> fastIterator() {
@@ -58,11 +88,13 @@ public class HashSet2D extends LongOpenHashSet {
 
         return new Iterator<>() {
 
+            @Contract(pure = true)
             @Override
             public boolean hasNext() {
                 return iter.hasNext();
             }
 
+            @Contract(mutates = "this")
             @Override
             public XZAddressable next() {
                 long l = iter.nextLong();
@@ -77,16 +109,5 @@ public class HashSet2D extends LongOpenHashSet {
 
     public Iterable<XZAddressable> fastEntryIterable() {
         return this::fastIterator;
-    }
-
-    /// The stream elements are backed by the same mutated {@link XZAddressable} instance as
-    /// {@link #fastIterator()}; collect {@code new MutableXZ(e.getX(), e.getZ())} if you need to retain them.
-    public Stream<XZAddressable> fastEntryStream() {
-        return StreamSupport.stream(
-                Spliterators.spliterator(
-                        fastEntryIterable().iterator(),
-                        size(),
-                        Spliterator.SIZED | Spliterator.NONNULL | Spliterator.DISTINCT),
-                false);
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashSet3D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashSet3D.java
@@ -1,0 +1,94 @@
+package com.gtnewhorizon.gtnhlib.datastructs.space;
+
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.pack;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.gtnewhorizon.gtnhlib.functional.Consumer3D;
+import com.gtnewhorizon.gtnhlib.space.MutableXYZ;
+import com.gtnewhorizon.gtnhlib.space.XYZAddressable;
+import com.gtnewhorizon.gtnhlib.util.CoordinatePacker;
+
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+
+@SuppressWarnings("unused")
+public class HashSet3D extends LongOpenHashSet {
+
+    public boolean contains(int posX, int posY, int posZ) {
+        return super.contains(pack(posX, posY, posZ));
+    }
+
+    public boolean contains(XYZAddressable xyz) {
+        return contains(xyz.getX(), xyz.getY(), xyz.getZ());
+    }
+
+    public boolean remove(int posX, int posY, int posZ) {
+        return super.remove(pack(posX, posY, posZ));
+    }
+
+    public boolean remove(XYZAddressable xyz) {
+        return remove(xyz.getX(), xyz.getY(), xyz.getZ());
+    }
+
+    public boolean add(int posX, int posY, int posZ) {
+        return super.add(pack(posX, posY, posZ));
+    }
+
+    public boolean add(XYZAddressable xyz) {
+        return add(xyz.getX(), xyz.getY(), xyz.getZ());
+    }
+
+    public void forEach(Consumer3D consumer) {
+        for (var e : this.fastEntryIterable()) {
+            consumer.accept(e.getX(), e.getY(), e.getZ());
+        }
+    }
+
+    /// The returned iterator always yields the same mutated {@link XYZAddressable} instance; do not retain the
+    /// result of {@link Iterator#next()} past the following call.
+    public Iterator<XYZAddressable> fastIterator() {
+        LongIterator iter = super.iterator();
+
+        MutableXYZ pos = new MutableXYZ();
+
+        return new Iterator<>() {
+
+            @Override
+            public boolean hasNext() {
+                return iter.hasNext();
+            }
+
+            @Override
+            public XYZAddressable next() {
+                long l = iter.nextLong();
+
+                pos.x = CoordinatePacker.unpackX(l);
+                pos.y = CoordinatePacker.unpackY(l);
+                pos.z = CoordinatePacker.unpackZ(l);
+
+                return pos;
+            }
+        };
+    }
+
+    public Iterable<XYZAddressable> fastEntryIterable() {
+        return this::fastIterator;
+    }
+
+    /// The stream elements are backed by the same mutated {@link XYZAddressable} instance as
+    /// {@link #fastIterator()}; collect {@code new MutableXYZ(e.getX(), e.getY(), e.getZ())} if you need to retain
+    /// them.
+    public Stream<XYZAddressable> fastEntryStream() {
+        return StreamSupport.stream(
+                Spliterators.spliterator(
+                        fastEntryIterable().iterator(),
+                        size(),
+                        Spliterator.SIZED | Spliterator.NONNULL | Spliterator.DISTINCT),
+                false);
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashSet3D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/datastructs/space/HashSet3D.java
@@ -8,6 +8,8 @@ import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.jetbrains.annotations.Contract;
+
 import com.gtnewhorizon.gtnhlib.functional.Consumer3D;
 import com.gtnewhorizon.gtnhlib.space.MutableXYZ;
 import com.gtnewhorizon.gtnhlib.space.XYZAddressable;
@@ -49,6 +51,34 @@ public class HashSet3D extends LongOpenHashSet {
         }
     }
 
+    public Iterator<XYZAddressable> slowIterator() {
+        LongIterator iter = super.iterator();
+
+        return new Iterator<>() {
+
+            @Contract(pure = true)
+            @Override
+            public boolean hasNext() {
+                return iter.hasNext();
+            }
+
+            @Contract(mutates = "this")
+            @Override
+            public XYZAddressable next() {
+                return MutableXYZ.unpack(iter.nextLong());
+            }
+        };
+    }
+
+    public Stream<XYZAddressable> slowStream() {
+        return StreamSupport.stream(
+                Spliterators.spliterator(
+                        this.slowIterator(),
+                        size(),
+                        Spliterator.SIZED | Spliterator.NONNULL | Spliterator.DISTINCT),
+                false);
+    }
+
     /// The returned iterator always yields the same mutated {@link XYZAddressable} instance; do not retain the
     /// result of {@link Iterator#next()} past the following call.
     public Iterator<XYZAddressable> fastIterator() {
@@ -58,11 +88,13 @@ public class HashSet3D extends LongOpenHashSet {
 
         return new Iterator<>() {
 
+            @Contract(pure = true)
             @Override
             public boolean hasNext() {
                 return iter.hasNext();
             }
 
+            @Contract(mutates = "this")
             @Override
             public XYZAddressable next() {
                 long l = iter.nextLong();
@@ -78,17 +110,5 @@ public class HashSet3D extends LongOpenHashSet {
 
     public Iterable<XYZAddressable> fastEntryIterable() {
         return this::fastIterator;
-    }
-
-    /// The stream elements are backed by the same mutated {@link XYZAddressable} instance as
-    /// {@link #fastIterator()}; collect {@code new MutableXYZ(e.getX(), e.getY(), e.getZ())} if you need to retain
-    /// them.
-    public Stream<XYZAddressable> fastEntryStream() {
-        return StreamSupport.stream(
-                Spliterators.spliterator(
-                        fastEntryIterable().iterator(),
-                        size(),
-                        Spliterator.SIZED | Spliterator.NONNULL | Spliterator.DISTINCT),
-                false);
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/functional/Compute2D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/functional/Compute2D.java
@@ -1,0 +1,7 @@
+package com.gtnewhorizon.gtnhlib.functional;
+
+@FunctionalInterface
+public interface Compute2D<V> {
+
+    V apply(int posX, int posZ);
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/functional/Compute2DWithValue.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/functional/Compute2DWithValue.java
@@ -1,0 +1,12 @@
+package com.gtnewhorizon.gtnhlib.functional;
+
+import org.jetbrains.annotations.Nullable;
+
+@FunctionalInterface
+public interface Compute2DWithValue<V> {
+
+    /// @param currentValue the value currently mapped at (posX, posZ), or null if absent
+    /// @return the new value to map, or null to remove the mapping
+    @Nullable
+    V apply(int posX, int posZ, @Nullable V currentValue);
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/functional/Compute3D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/functional/Compute3D.java
@@ -1,0 +1,7 @@
+package com.gtnewhorizon.gtnhlib.functional;
+
+@FunctionalInterface
+public interface Compute3D<V> {
+
+    V apply(int posX, int posY, int posZ);
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/functional/Compute3DWithValue.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/functional/Compute3DWithValue.java
@@ -1,0 +1,12 @@
+package com.gtnewhorizon.gtnhlib.functional;
+
+import org.jetbrains.annotations.Nullable;
+
+@FunctionalInterface
+public interface Compute3DWithValue<V> {
+
+    /// @param currentValue the value currently mapped at (posX, posY, posZ), or null if absent
+    /// @return the new value to map, or null to remove the mapping
+    @Nullable
+    V apply(int posX, int posY, int posZ, @Nullable V currentValue);
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/functional/Consumer2D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/functional/Consumer2D.java
@@ -1,0 +1,7 @@
+package com.gtnewhorizon.gtnhlib.functional;
+
+@FunctionalInterface
+public interface Consumer2D {
+
+    void accept(int posX, int posZ);
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/functional/Consumer2DWithValue.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/functional/Consumer2DWithValue.java
@@ -1,0 +1,7 @@
+package com.gtnewhorizon.gtnhlib.functional;
+
+@FunctionalInterface
+public interface Consumer2DWithValue<T> {
+
+    void accept(int posX, int posZ, T value);
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/functional/Consumer3D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/functional/Consumer3D.java
@@ -1,0 +1,7 @@
+package com.gtnewhorizon.gtnhlib.functional;
+
+@FunctionalInterface
+public interface Consumer3D {
+
+    void accept(int posX, int posY, int posZ);
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/functional/Consumer3DWithValue.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/functional/Consumer3DWithValue.java
@@ -1,0 +1,7 @@
+package com.gtnewhorizon.gtnhlib.functional;
+
+@FunctionalInterface
+public interface Consumer3DWithValue<T> {
+
+    void accept(int posX, int posY, int posZ, T value);
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/space/ImmutableXYZ.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/space/ImmutableXYZ.java
@@ -1,0 +1,28 @@
+package com.gtnewhorizon.gtnhlib.space;
+
+import com.github.bsideup.jabel.Desugar;
+import com.gtnewhorizon.gtnhlib.hash.Fnv1a32;
+
+@Desugar
+public record ImmutableXYZ(int x, int y, int z) implements XYZAddressable {
+
+    @Override
+    public int getX() {
+        return x;
+    }
+
+    @Override
+    public int getY() {
+        return y;
+    }
+
+    @Override
+    public int getZ() {
+        return z;
+    }
+
+    @Override
+    public int hashCode() {
+        return Fnv1a32.hashStep(Fnv1a32.hashStep(Fnv1a32.hashStep(Fnv1a32.initialState(), x), y), z);
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/space/ImmutableXYZ.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/space/ImmutableXYZ.java
@@ -1,10 +1,18 @@
 package com.gtnewhorizon.gtnhlib.space;
 
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackX;
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackY;
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackZ;
+
 import com.github.bsideup.jabel.Desugar;
 import com.gtnewhorizon.gtnhlib.hash.Fnv1a32;
 
 @Desugar
 public record ImmutableXYZ(int x, int y, int z) implements XYZAddressable {
+
+    public static ImmutableXYZ unpack(long coord) {
+        return new ImmutableXYZ(unpackX(coord), unpackY(coord), unpackZ(coord));
+    }
 
     @Override
     public int getX() {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/space/ImmutableXZ.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/space/ImmutableXZ.java
@@ -1,0 +1,23 @@
+package com.gtnewhorizon.gtnhlib.space;
+
+import com.github.bsideup.jabel.Desugar;
+import com.gtnewhorizon.gtnhlib.hash.Fnv1a32;
+
+@Desugar
+public record ImmutableXZ(int x, int z) implements XZAddressable {
+
+    @Override
+    public int getX() {
+        return x;
+    }
+
+    @Override
+    public int getZ() {
+        return z;
+    }
+
+    @Override
+    public int hashCode() {
+        return Fnv1a32.hashStep(Fnv1a32.hashStep(Fnv1a32.initialState(), x), z);
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/space/ImmutableXZ.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/space/ImmutableXZ.java
@@ -2,9 +2,14 @@ package com.gtnewhorizon.gtnhlib.space;
 
 import com.github.bsideup.jabel.Desugar;
 import com.gtnewhorizon.gtnhlib.hash.Fnv1a32;
+import com.gtnewhorizon.gtnhlib.util.CoordinatePacker2D;
 
 @Desugar
 public record ImmutableXZ(int x, int z) implements XZAddressable {
+
+    public static ImmutableXZ unpack(long coord) {
+        return new ImmutableXZ(CoordinatePacker2D.unpackChunkX(coord), CoordinatePacker2D.unpackChunkZ(coord));
+    }
 
     @Override
     public int getX() {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/space/MutableXYZ.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/space/MutableXYZ.java
@@ -1,5 +1,9 @@
 package com.gtnewhorizon.gtnhlib.space;
 
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackX;
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackY;
+import static com.gtnewhorizon.gtnhlib.util.CoordinatePacker.unpackZ;
+
 import com.gtnewhorizon.gtnhlib.hash.Fnv1a32;
 
 public class MutableXYZ implements XYZAddressable {
@@ -12,6 +16,10 @@ public class MutableXYZ implements XYZAddressable {
         this.x = x;
         this.y = y;
         this.z = z;
+    }
+
+    public static MutableXYZ unpack(long coord) {
+        return new MutableXYZ(unpackX(coord), unpackY(coord), unpackZ(coord));
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/gtnhlib/space/MutableXYZ.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/space/MutableXYZ.java
@@ -1,0 +1,48 @@
+package com.gtnewhorizon.gtnhlib.space;
+
+import com.gtnewhorizon.gtnhlib.hash.Fnv1a32;
+
+public class MutableXYZ implements XYZAddressable {
+
+    public int x, y, z;
+
+    public MutableXYZ() {}
+
+    public MutableXYZ(int x, int y, int z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    @Override
+    public int getX() {
+        return x;
+    }
+
+    @Override
+    public int getY() {
+        return y;
+    }
+
+    @Override
+    public int getZ() {
+        return z;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof MutableXYZ that)) return false;
+
+        return x == that.x && y == that.y && z == that.z;
+    }
+
+    @Override
+    public int hashCode() {
+        return Fnv1a32.hashStep(Fnv1a32.hashStep(Fnv1a32.hashStep(Fnv1a32.initialState(), x), y), z);
+    }
+
+    @Override
+    public String toString() {
+        return "MutableXYZ{" + "x=" + x + ", y=" + y + ", z=" + z + '}';
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/space/MutableXZ.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/space/MutableXZ.java
@@ -1,0 +1,42 @@
+package com.gtnewhorizon.gtnhlib.space;
+
+import com.gtnewhorizon.gtnhlib.hash.Fnv1a32;
+
+public class MutableXZ implements XZAddressable {
+
+    public int x, z;
+
+    public MutableXZ() {}
+
+    public MutableXZ(int x, int z) {
+        this.x = x;
+        this.z = z;
+    }
+
+    @Override
+    public int getX() {
+        return x;
+    }
+
+    @Override
+    public int getZ() {
+        return z;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof MutableXZ mutableXZ)) return false;
+
+        return x == mutableXZ.x && z == mutableXZ.z;
+    }
+
+    @Override
+    public int hashCode() {
+        return Fnv1a32.hashStep(Fnv1a32.hashStep(Fnv1a32.initialState(), x), z);
+    }
+
+    @Override
+    public String toString() {
+        return "MutableXZ{" + "x=" + x + ", z=" + z + '}';
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/space/MutableXZ.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/space/MutableXZ.java
@@ -1,6 +1,7 @@
 package com.gtnewhorizon.gtnhlib.space;
 
 import com.gtnewhorizon.gtnhlib.hash.Fnv1a32;
+import com.gtnewhorizon.gtnhlib.util.CoordinatePacker2D;
 
 public class MutableXZ implements XZAddressable {
 
@@ -11,6 +12,10 @@ public class MutableXZ implements XZAddressable {
     public MutableXZ(int x, int z) {
         this.x = x;
         this.z = z;
+    }
+
+    public static MutableXZ unpack(long coord) {
+        return new MutableXZ(CoordinatePacker2D.unpackChunkX(coord), CoordinatePacker2D.unpackChunkZ(coord));
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/gtnhlib/space/XYZAddressable.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/space/XYZAddressable.java
@@ -1,0 +1,12 @@
+package com.gtnewhorizon.gtnhlib.space;
+
+/// Something that exists at an X,Y,Z location.
+public interface XYZAddressable {
+
+    int getX();
+
+    int getY();
+
+    int getZ();
+
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/space/XZAddressable.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/space/XZAddressable.java
@@ -1,0 +1,9 @@
+package com.gtnewhorizon.gtnhlib.space;
+
+/// Something that exists at an X,Z location.
+public interface XZAddressable {
+
+    int getX();
+
+    int getZ();
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/CoordinatePacker2D.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/CoordinatePacker2D.java
@@ -1,0 +1,18 @@
+package com.gtnewhorizon.gtnhlib.util;
+
+public class CoordinatePacker2D {
+
+    private static final long XZ_INT = 0xFFFFFFFFL;
+
+    public static long packChunk(int x, int z) {
+        return (z & XZ_INT) << 32 | (x & XZ_INT);
+    }
+
+    public static int unpackChunkX(long key) {
+        return (int) key;
+    }
+
+    public static int unpackChunkZ(long key) {
+        return (int) (key >> 32);
+    }
+}

--- a/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashMap2DTest.java
+++ b/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashMap2DTest.java
@@ -1,0 +1,324 @@
+package com.gtnewhorizon.gtnhlib.test.datastructs.space;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.gtnewhorizon.gtnhlib.datastructs.space.HashMap2D;
+import com.gtnewhorizon.gtnhlib.datastructs.space.HashMap2D.Entry2D;
+import com.gtnewhorizon.gtnhlib.space.ImmutableXZ;
+
+class HashMap2DTest {
+
+    private HashMap2D<String> map;
+
+    @BeforeEach
+    void setUp() {
+        map = new HashMap2D<>();
+    }
+
+    @Test
+    void putAndGetByCoordinates() {
+        assertNull(map.put(1, 2, "A"));
+        assertEquals("A", map.get(1, 2));
+        assertNull(map.get(2, 1));
+    }
+
+    @Test
+    void putAndGetByAddressable() {
+        ImmutableXZ pos = new ImmutableXZ(3, 4);
+        map.put(pos, "B");
+        assertEquals("B", map.get(pos));
+        assertEquals("B", map.get(3, 4));
+    }
+
+    @Test
+    void containsKey() {
+        assertFalse(map.containsKey(1, 1));
+        map.put(1, 1, "A");
+        assertTrue(map.containsKey(1, 1));
+        assertTrue(map.containsKey(new ImmutableXZ(1, 1)));
+    }
+
+    @Test
+    void removeByCoordinatesReturnsOldValue() {
+        map.put(5, 6, "A");
+        assertEquals("A", map.remove(5, 6));
+        assertNull(map.get(5, 6));
+        assertNull(map.remove(5, 6));
+    }
+
+    @Test
+    void removeByAddressable() {
+        ImmutableXZ pos = new ImmutableXZ(7, 8);
+        map.put(pos, "A");
+        assertEquals("A", map.remove(pos));
+        assertFalse(map.containsKey(pos));
+    }
+
+    @Test
+    void removeWithValueMatchOnlyRemovesOnMatch() {
+        map.put(1, 1, "A");
+        assertFalse(map.remove(1, 1, "B"));
+        assertEquals("A", map.get(1, 1));
+        assertTrue(map.remove(1, 1, "A"));
+        assertNull(map.get(1, 1));
+    }
+
+    @Test
+    void computeIfAbsentComputesOnceAndReusesExisting() {
+        assertEquals("A", map.computeIfAbsent(1, 1, (x, z) -> "A"));
+        assertEquals("A", map.computeIfAbsent(1, 1, (x, z) -> "B"));
+    }
+
+    @Test
+    void computeAppliesRemappingFunctionWithCoordinates() {
+        map.put(1, 1, "A");
+        String result = map.compute(1, 1, (x, z, v) -> v + x + z);
+        assertEquals("A11", result);
+        assertEquals("A11", map.get(1, 1));
+    }
+
+    @Test
+    void computeIfPresentSkipsMissingKeys() {
+        assertNull(map.computeIfPresent(1, 1, (x, z, v) -> "shouldNotRun"));
+        map.put(1, 1, "A");
+        assertEquals("A!", map.computeIfPresent(1, 1, (x, z, v) -> v + "!"));
+    }
+
+    @Test
+    void getOrDefaultReturnsDefaultWhenMissing() {
+        assertEquals("D", map.getOrDefault(1, 1, "D"));
+        map.put(1, 1, "A");
+        assertEquals("A", map.getOrDefault(1, 1, "D"));
+    }
+
+    @Test
+    void putIfAbsentTreatsNullValueAsPresent() {
+        assertNull(map.putIfAbsent(1, 1, null));
+        assertTrue(map.containsKey(1, 1));
+        assertNull(map.putIfAbsent(1, 1, "A"));
+        assertNull(map.get(1, 1));
+    }
+
+    @Test
+    void replaceOnlyAffectsExistingKeys() {
+        assertNull(map.replace(1, 1, "A"));
+        assertFalse(map.containsKey(1, 1));
+        map.put(1, 1, "A");
+        assertEquals("A", map.replace(1, 1, "B"));
+        assertEquals("B", map.get(1, 1));
+    }
+
+    @Test
+    void replaceWithOldValueMatchOnlyReplacesOnMatch() {
+        map.put(1, 1, "A");
+        assertFalse(map.replace(1, 1, "WRONG", "B"));
+        assertEquals("A", map.get(1, 1));
+        assertTrue(map.replace(1, 1, "A", "B"));
+        assertEquals("B", map.get(1, 1));
+    }
+
+    @Test
+    void mergeCombinesValues() {
+        map.put(1, 1, "A");
+        map.merge(1, 1, "B", (oldV, newV) -> oldV + newV);
+        assertEquals("AB", map.get(1, 1));
+    }
+
+    @Test
+    void forEachVisitsAllEntriesWithCoordinates() {
+        map.put(1, 2, "A");
+        map.put(3, 4, "B");
+
+        Set<String> seen = new HashSet<>();
+        map.forEach((x, z, v) -> seen.add(x + "," + z + "=" + v));
+
+        Set<String> expected = new HashSet<>(Arrays.asList("1,2=A", "3,4=B"));
+        assertEquals(expected, seen);
+    }
+
+    @Test
+    void replaceAllRewritesValuesBasedOnCoordinates() {
+        map.put(1, 2, "A");
+        map.put(3, 4, "B");
+
+        map.replaceAll((x, z, v) -> v + x + z);
+
+        assertEquals("A12", map.get(1, 2));
+        assertEquals("B34", map.get(3, 4));
+    }
+
+    @Test
+    void fastEntryIterableExposesCoordinatesAndValues() {
+        map.put(1, 2, "A");
+
+        var entries = map.fastEntryIterable().iterator();
+        assertTrue(entries.hasNext());
+        var entry = entries.next();
+        assertEquals(1, entry.getX());
+        assertEquals(2, entry.getZ());
+        assertEquals("A", entry.getValue());
+        assertFalse(entries.hasNext());
+    }
+
+    @Test
+    void fastEntryStreamCountMatchesSize() {
+        map.put(1, 2, "A");
+        map.put(3, 4, "B");
+
+        assertEquals(2, map.fastEntryStream().count());
+    }
+
+    @Test
+    void negativeCoordinatesAreDistinctFromPositive() {
+        map.put(-1, -2, "Neg");
+        map.put(1, 2, "Pos");
+
+        assertEquals("Neg", map.get(-1, -2));
+        assertEquals("Pos", map.get(1, 2));
+        assertEquals(2, map.size());
+    }
+
+    @Test
+    void computeIfAbsentByAddressableDelegatesToCoordinates() {
+        ImmutableXZ pos = new ImmutableXZ(1, 1);
+        assertEquals("A", map.computeIfAbsent(pos, (x, z) -> "A"));
+        assertEquals("A", map.computeIfAbsent(pos, (x, z) -> "B"));
+    }
+
+    @Test
+    void computeByAddressableDelegatesToCoordinates() {
+        ImmutableXZ pos = new ImmutableXZ(1, 1);
+        map.put(pos, "A");
+        assertEquals("A11", map.compute(pos, (x, z, v) -> v + x + z));
+    }
+
+    @Test
+    void computeIfPresentByAddressableDelegatesToCoordinates() {
+        ImmutableXZ pos = new ImmutableXZ(1, 1);
+        assertNull(map.computeIfPresent(pos, (x, z, v) -> "shouldNotRun"));
+        map.put(pos, "A");
+        assertEquals("A!", map.computeIfPresent(pos, (x, z, v) -> v + "!"));
+    }
+
+    @Test
+    void getOrDefaultByAddressableDelegatesToCoordinates() {
+        ImmutableXZ pos = new ImmutableXZ(1, 1);
+        assertEquals("D", map.getOrDefault(pos, "D"));
+        map.put(pos, "A");
+        assertEquals("A", map.getOrDefault(pos, "D"));
+    }
+
+    @Test
+    void putIfAbsentByAddressableDelegatesToCoordinates() {
+        ImmutableXZ pos = new ImmutableXZ(1, 1);
+        assertNull(map.putIfAbsent(pos, "A"));
+        assertEquals("A", map.putIfAbsent(pos, "B"));
+        assertEquals("A", map.get(pos));
+    }
+
+    @Test
+    void removeWithValueMatchByAddressable() {
+        ImmutableXZ pos = new ImmutableXZ(1, 1);
+        map.put(pos, "A");
+        assertFalse(map.remove(pos, "B"));
+        assertTrue(map.remove(pos, "A"));
+        assertNull(map.get(pos));
+    }
+
+    @Test
+    void replaceByAddressable() {
+        ImmutableXZ pos = new ImmutableXZ(1, 1);
+        assertNull(map.replace(pos, "A"));
+        map.put(pos, "A");
+        assertEquals("A", map.replace(pos, "B"));
+        assertEquals("B", map.get(pos));
+    }
+
+    @Test
+    void replaceWithOldValueMatchByAddressable() {
+        ImmutableXZ pos = new ImmutableXZ(1, 1);
+        map.put(pos, "A");
+        assertFalse(map.replace(pos, "WRONG", "B"));
+        assertTrue(map.replace(pos, "A", "B"));
+        assertEquals("B", map.get(pos));
+    }
+
+    @Test
+    void mergeByAddressableDelegatesToCoordinates() {
+        ImmutableXZ pos = new ImmutableXZ(1, 1);
+        map.put(pos, "A");
+        map.merge(pos, "B", (oldV, newV) -> oldV + newV);
+        assertEquals("AB", map.get(pos));
+    }
+
+    @Test
+    void fastEntrySetIsCachedAndReflectsSize() {
+        map.put(1, 2, "A");
+        map.put(3, 4, "B");
+
+        var entrySet = map.fastEntrySet();
+        assertSame(entrySet, map.fastEntrySet());
+        assertEquals(2, entrySet.size());
+    }
+
+    @Test
+    void fastEntrySetFastForEachVisitsAllEntries() {
+        map.put(1, 2, "A");
+        map.put(3, 4, "B");
+
+        Set<String> seen = new HashSet<>();
+        map.fastEntrySet().fastForEach(e -> seen.add(e.getX() + "," + e.getZ() + "=" + e.getValue()));
+
+        assertEquals(new HashSet<>(Arrays.asList("1,2=A", "3,4=B")), seen);
+    }
+
+    @Test
+    void fastEntrySetIteratorReturnsIndependentBoxedEntries() {
+        map.put(1, 2, "A");
+        map.put(3, 4, "B");
+
+        var iter = map.fastEntrySet().iterator();
+        Entry2D<String> first = iter.next();
+        Entry2D<String> second = iter.next();
+
+        assertNotSame(first, second);
+        Set<String> seen = new HashSet<>();
+        seen.add(first.getX() + "," + first.getZ() + "=" + first.getValue());
+        seen.add(second.getX() + "," + second.getZ() + "=" + second.getValue());
+        assertEquals(new HashSet<>(Arrays.asList("1,2=A", "3,4=B")), seen);
+    }
+
+    @Test
+    void entry2DLongKeyConstructorUnpacksCoordinates() {
+        ImmutableXZ pos = new ImmutableXZ(1, 2);
+        map.put(pos, "A");
+        long key = map.fastEntryIterable().iterator().next().getLongKey();
+
+        Entry2D<String> entry = new Entry2D<>(key, "A");
+        assertEquals(1, entry.getX());
+        assertEquals(2, entry.getZ());
+        assertEquals("A", entry.getValue());
+    }
+
+    @Test
+    void entry2DCoordinateConstructorPacksCoordinates() {
+        Entry2D<String> entry = new Entry2D<>(1, 2, "A");
+        assertEquals(1, entry.getX());
+        assertEquals(2, entry.getZ());
+        assertEquals("A", entry.getValue());
+    }
+
+    @Test
+    void entry2DSetValueReturnsOldValue() {
+        Entry2D<String> entry = new Entry2D<>(1, 2, "A");
+        assertEquals("A", entry.setValue("B"));
+        assertEquals("B", entry.getValue());
+    }
+}

--- a/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashMap2DTest.java
+++ b/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashMap2DTest.java
@@ -3,8 +3,10 @@ package com.gtnewhorizon.gtnhlib.test.datastructs.space;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -168,11 +170,41 @@ class HashMap2DTest {
     }
 
     @Test
-    void fastEntryStreamCountMatchesSize() {
+    void slowIteratorReturnsIndependentEntries() {
         map.put(1, 2, "A");
         map.put(3, 4, "B");
 
-        assertEquals(2, map.fastEntryStream().count());
+        var iter = map.slowIterator();
+        Entry2D<String> first = iter.next();
+        Entry2D<String> second = iter.next();
+
+        assertNotSame(first, second);
+        Set<String> seen = new HashSet<>();
+        seen.add(first.getX() + "," + first.getZ() + "=" + first.getValue());
+        seen.add(second.getX() + "," + second.getZ() + "=" + second.getValue());
+        assertEquals(new HashSet<>(Arrays.asList("1,2=A", "3,4=B")), seen);
+    }
+
+    @Test
+    void slowStreamCountMatchesSize() {
+        map.put(1, 2, "A");
+        map.put(3, 4, "B");
+
+        assertEquals(2, map.slowStream().count());
+    }
+
+    @Test
+    void slowStreamElementsSurviveBuffering() {
+        map.put(1, 2, "A");
+        map.put(3, 4, "B");
+
+        // sorted() buffers every element before emitting; slowStream must not share mutable state
+        // across entries the way fastEntryStream() used to, or every entry would collapse to the last one.
+        Set<String> collected = map.slowStream().sorted(Comparator.comparingInt(Entry2D::getX))
+                .map(e -> e.getX() + "," + e.getZ() + "=" + e.getValue())
+                .collect(Collectors.toCollection(HashSet::new));
+
+        assertEquals(new HashSet<>(Arrays.asList("1,2=A", "3,4=B")), collected);
     }
 
     @Test

--- a/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashMap3DTest.java
+++ b/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashMap3DTest.java
@@ -3,8 +3,10 @@ package com.gtnewhorizon.gtnhlib.test.datastructs.space;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -168,11 +170,41 @@ class HashMap3DTest {
     }
 
     @Test
-    void fastEntryStreamCountMatchesSize() {
+    void slowIteratorReturnsIndependentEntries() {
         map.put(1, 2, 3, "A");
         map.put(4, 5, 6, "B");
 
-        assertEquals(2, map.fastEntryStream().count());
+        var iter = map.slowIterator();
+        Entry3D<String> first = iter.next();
+        Entry3D<String> second = iter.next();
+
+        assertNotSame(first, second);
+        Set<String> seen = new HashSet<>();
+        seen.add(first.getX() + "," + first.getY() + "," + first.getZ() + "=" + first.getValue());
+        seen.add(second.getX() + "," + second.getY() + "," + second.getZ() + "=" + second.getValue());
+        assertEquals(new HashSet<>(Arrays.asList("1,2,3=A", "4,5,6=B")), seen);
+    }
+
+    @Test
+    void slowStreamCountMatchesSize() {
+        map.put(1, 2, 3, "A");
+        map.put(4, 5, 6, "B");
+
+        assertEquals(2, map.slowStream().count());
+    }
+
+    @Test
+    void slowStreamElementsSurviveBuffering() {
+        map.put(1, 2, 3, "A");
+        map.put(4, 5, 6, "B");
+
+        // sorted() buffers every element before emitting; slowStream must not share mutable state
+        // across entries the way fastEntryStream() used to, or every entry would collapse to the last one.
+        Set<String> collected = map.slowStream().sorted(Comparator.comparingInt(Entry3D::getX))
+                .map(e -> e.getX() + "," + e.getY() + "," + e.getZ() + "=" + e.getValue())
+                .collect(Collectors.toCollection(HashSet::new));
+
+        assertEquals(new HashSet<>(Arrays.asList("1,2,3=A", "4,5,6=B")), collected);
     }
 
     @Test

--- a/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashMap3DTest.java
+++ b/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashMap3DTest.java
@@ -1,0 +1,326 @@
+package com.gtnewhorizon.gtnhlib.test.datastructs.space;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.gtnewhorizon.gtnhlib.datastructs.space.HashMap3D;
+import com.gtnewhorizon.gtnhlib.datastructs.space.HashMap3D.Entry3D;
+import com.gtnewhorizon.gtnhlib.space.ImmutableXYZ;
+
+class HashMap3DTest {
+
+    private HashMap3D<String> map;
+
+    @BeforeEach
+    void setUp() {
+        map = new HashMap3D<>();
+    }
+
+    @Test
+    void putAndGetByCoordinates() {
+        assertNull(map.put(1, 2, 3, "A"));
+        assertEquals("A", map.get(1, 2, 3));
+        assertNull(map.get(3, 2, 1));
+    }
+
+    @Test
+    void putAndGetByAddressable() {
+        ImmutableXYZ pos = new ImmutableXYZ(3, 4, 5);
+        map.put(pos, "B");
+        assertEquals("B", map.get(pos));
+        assertEquals("B", map.get(3, 4, 5));
+    }
+
+    @Test
+    void containsKey() {
+        assertFalse(map.containsKey(1, 1, 1));
+        map.put(1, 1, 1, "A");
+        assertTrue(map.containsKey(1, 1, 1));
+        assertTrue(map.containsKey(new ImmutableXYZ(1, 1, 1)));
+    }
+
+    @Test
+    void removeByCoordinatesReturnsOldValue() {
+        map.put(5, 6, 7, "A");
+        assertEquals("A", map.remove(5, 6, 7));
+        assertNull(map.get(5, 6, 7));
+        assertNull(map.remove(5, 6, 7));
+    }
+
+    @Test
+    void removeByAddressable() {
+        ImmutableXYZ pos = new ImmutableXYZ(7, 8, 9);
+        map.put(pos, "A");
+        assertEquals("A", map.remove(pos));
+        assertFalse(map.containsKey(pos));
+    }
+
+    @Test
+    void removeWithValueMatchOnlyRemovesOnMatch() {
+        map.put(1, 1, 1, "A");
+        assertFalse(map.remove(1, 1, 1, "B"));
+        assertEquals("A", map.get(1, 1, 1));
+        assertTrue(map.remove(1, 1, 1, "A"));
+        assertNull(map.get(1, 1, 1));
+    }
+
+    @Test
+    void computeIfAbsentComputesOnceAndReusesExisting() {
+        assertEquals("A", map.computeIfAbsent(1, 1, 1, (x, y, z) -> "A"));
+        assertEquals("A", map.computeIfAbsent(1, 1, 1, (x, y, z) -> "B"));
+    }
+
+    @Test
+    void computeAppliesRemappingFunctionWithCoordinates() {
+        map.put(1, 1, 1, "A");
+        String result = map.compute(1, 1, 1, (x, y, z, v) -> v + x + y + z);
+        assertEquals("A111", result);
+        assertEquals("A111", map.get(1, 1, 1));
+    }
+
+    @Test
+    void computeIfPresentSkipsMissingKeys() {
+        assertNull(map.computeIfPresent(1, 1, 1, (x, y, z, v) -> "shouldNotRun"));
+        map.put(1, 1, 1, "A");
+        assertEquals("A!", map.computeIfPresent(1, 1, 1, (x, y, z, v) -> v + "!"));
+    }
+
+    @Test
+    void getOrDefaultReturnsDefaultWhenMissing() {
+        assertEquals("D", map.getOrDefault(1, 1, 1, "D"));
+        map.put(1, 1, 1, "A");
+        assertEquals("A", map.getOrDefault(1, 1, 1, "D"));
+    }
+
+    @Test
+    void putIfAbsentTreatsNullValueAsPresent() {
+        assertNull(map.putIfAbsent(1, 1, 1, null));
+        assertTrue(map.containsKey(1, 1, 1));
+        assertNull(map.putIfAbsent(1, 1, 1, "A"));
+        assertNull(map.get(1, 1, 1));
+    }
+
+    @Test
+    void replaceOnlyAffectsExistingKeys() {
+        assertNull(map.replace(1, 1, 1, "A"));
+        assertFalse(map.containsKey(1, 1, 1));
+        map.put(1, 1, 1, "A");
+        assertEquals("A", map.replace(1, 1, 1, "B"));
+        assertEquals("B", map.get(1, 1, 1));
+    }
+
+    @Test
+    void replaceWithOldValueMatchOnlyReplacesOnMatch() {
+        map.put(1, 1, 1, "A");
+        assertFalse(map.replace(1, 1, 1, "WRONG", "B"));
+        assertEquals("A", map.get(1, 1, 1));
+        assertTrue(map.replace(1, 1, 1, "A", "B"));
+        assertEquals("B", map.get(1, 1, 1));
+    }
+
+    @Test
+    void mergeCombinesValues() {
+        map.put(1, 1, 1, "A");
+        map.merge(1, 1, 1, "B", (oldV, newV) -> oldV + newV);
+        assertEquals("AB", map.get(1, 1, 1));
+    }
+
+    @Test
+    void forEachVisitsAllEntriesWithCoordinates() {
+        map.put(1, 2, 3, "A");
+        map.put(4, 5, 6, "B");
+
+        Set<String> seen = new HashSet<>();
+        map.forEach((x, y, z, v) -> seen.add(x + "," + y + "," + z + "=" + v));
+
+        assertEquals(new HashSet<>(Arrays.asList("1,2,3=A", "4,5,6=B")), seen);
+    }
+
+    @Test
+    void replaceAllRewritesValuesBasedOnCoordinates() {
+        map.put(1, 2, 3, "A");
+        map.put(4, 5, 6, "B");
+
+        map.replaceAll((x, y, z, v) -> v + x + y + z);
+
+        assertEquals("A123", map.get(1, 2, 3));
+        assertEquals("B456", map.get(4, 5, 6));
+    }
+
+    @Test
+    void fastEntryIterableExposesCoordinatesAndValues() {
+        map.put(1, 2, 3, "A");
+
+        var entries = map.fastEntryIterable().iterator();
+        assertTrue(entries.hasNext());
+        var entry = entries.next();
+        assertEquals(1, entry.getX());
+        assertEquals(2, entry.getY());
+        assertEquals(3, entry.getZ());
+        assertEquals("A", entry.getValue());
+        assertFalse(entries.hasNext());
+    }
+
+    @Test
+    void fastEntryStreamCountMatchesSize() {
+        map.put(1, 2, 3, "A");
+        map.put(4, 5, 6, "B");
+
+        assertEquals(2, map.fastEntryStream().count());
+    }
+
+    @Test
+    void negativeCoordinatesAreDistinctFromPositive() {
+        map.put(-1, -2, -3, "Neg");
+        map.put(1, 2, 3, "Pos");
+
+        assertEquals("Neg", map.get(-1, -2, -3));
+        assertEquals("Pos", map.get(1, 2, 3));
+        assertEquals(2, map.size());
+    }
+
+    @Test
+    void computeIfAbsentByAddressableDelegatesToCoordinates() {
+        ImmutableXYZ pos = new ImmutableXYZ(1, 1, 1);
+        assertEquals("A", map.computeIfAbsent(pos, (x, y, z) -> "A"));
+        assertEquals("A", map.computeIfAbsent(pos, (x, y, z) -> "B"));
+    }
+
+    @Test
+    void computeByAddressableDelegatesToCoordinates() {
+        ImmutableXYZ pos = new ImmutableXYZ(1, 1, 1);
+        map.put(pos, "A");
+        assertEquals("A111", map.compute(pos, (x, y, z, v) -> v + x + y + z));
+    }
+
+    @Test
+    void computeIfPresentByAddressableDelegatesToCoordinates() {
+        ImmutableXYZ pos = new ImmutableXYZ(1, 1, 1);
+        assertNull(map.computeIfPresent(pos, (x, y, z, v) -> "shouldNotRun"));
+        map.put(pos, "A");
+        assertEquals("A!", map.computeIfPresent(pos, (x, y, z, v) -> v + "!"));
+    }
+
+    @Test
+    void getOrDefaultByAddressableDelegatesToCoordinates() {
+        ImmutableXYZ pos = new ImmutableXYZ(1, 1, 1);
+        assertEquals("D", map.getOrDefault(pos, "D"));
+        map.put(pos, "A");
+        assertEquals("A", map.getOrDefault(pos, "D"));
+    }
+
+    @Test
+    void putIfAbsentByAddressableDelegatesToCoordinates() {
+        ImmutableXYZ pos = new ImmutableXYZ(1, 1, 1);
+        assertNull(map.putIfAbsent(pos, "A"));
+        assertEquals("A", map.putIfAbsent(pos, "B"));
+        assertEquals("A", map.get(pos));
+    }
+
+    @Test
+    void removeWithValueMatchByAddressable() {
+        ImmutableXYZ pos = new ImmutableXYZ(1, 1, 1);
+        map.put(pos, "A");
+        assertFalse(map.remove(pos, "B"));
+        assertTrue(map.remove(pos, "A"));
+        assertNull(map.get(pos));
+    }
+
+    @Test
+    void replaceByAddressable() {
+        ImmutableXYZ pos = new ImmutableXYZ(1, 1, 1);
+        assertNull(map.replace(pos, "A"));
+        map.put(pos, "A");
+        assertEquals("A", map.replace(pos, "B"));
+        assertEquals("B", map.get(pos));
+    }
+
+    @Test
+    void replaceWithOldValueMatchByAddressable() {
+        ImmutableXYZ pos = new ImmutableXYZ(1, 1, 1);
+        map.put(pos, "A");
+        assertFalse(map.replace(pos, "WRONG", "B"));
+        assertTrue(map.replace(pos, "A", "B"));
+        assertEquals("B", map.get(pos));
+    }
+
+    @Test
+    void mergeByAddressableDelegatesToCoordinates() {
+        ImmutableXYZ pos = new ImmutableXYZ(1, 1, 1);
+        map.put(pos, "A");
+        map.merge(pos, "B", (oldV, newV) -> oldV + newV);
+        assertEquals("AB", map.get(pos));
+    }
+
+    @Test
+    void fastEntrySetIsCachedAndReflectsSize() {
+        map.put(1, 2, 3, "A");
+        map.put(4, 5, 6, "B");
+
+        var entrySet = map.fastEntrySet();
+        assertSame(entrySet, map.fastEntrySet());
+        assertEquals(2, entrySet.size());
+    }
+
+    @Test
+    void fastEntrySetFastForEachVisitsAllEntries() {
+        map.put(1, 2, 3, "A");
+        map.put(4, 5, 6, "B");
+
+        Set<String> seen = new HashSet<>();
+        map.fastEntrySet().fastForEach(e -> seen.add(e.getX() + "," + e.getY() + "," + e.getZ() + "=" + e.getValue()));
+
+        assertEquals(new HashSet<>(Arrays.asList("1,2,3=A", "4,5,6=B")), seen);
+    }
+
+    @Test
+    void fastEntrySetIteratorReturnsIndependentBoxedEntries() {
+        map.put(1, 2, 3, "A");
+        map.put(4, 5, 6, "B");
+
+        var iter = map.fastEntrySet().iterator();
+        Entry3D<String> first = iter.next();
+        Entry3D<String> second = iter.next();
+
+        assertNotSame(first, second);
+        Set<String> seen = new HashSet<>();
+        seen.add(first.getX() + "," + first.getY() + "," + first.getZ() + "=" + first.getValue());
+        seen.add(second.getX() + "," + second.getY() + "," + second.getZ() + "=" + second.getValue());
+        assertEquals(new HashSet<>(Arrays.asList("1,2,3=A", "4,5,6=B")), seen);
+    }
+
+    @Test
+    void entry3DLongKeyConstructorUnpacksCoordinates() {
+        ImmutableXYZ pos = new ImmutableXYZ(1, 2, 3);
+        map.put(pos, "A");
+        long key = map.fastEntryIterable().iterator().next().getLongKey();
+
+        Entry3D<String> entry = new Entry3D<>(key, "A");
+        assertEquals(1, entry.getX());
+        assertEquals(2, entry.getY());
+        assertEquals(3, entry.getZ());
+        assertEquals("A", entry.getValue());
+    }
+
+    @Test
+    void entry3DCoordinateConstructorPacksCoordinates() {
+        Entry3D<String> entry = new Entry3D<>(1, 2, 3, "A");
+        assertEquals(1, entry.getX());
+        assertEquals(2, entry.getY());
+        assertEquals(3, entry.getZ());
+        assertEquals("A", entry.getValue());
+    }
+
+    @Test
+    void entry3DSetValueReturnsOldValue() {
+        Entry3D<String> entry = new Entry3D<>(1, 2, 3, "A");
+        assertEquals("A", entry.setValue("B"));
+        assertEquals("B", entry.getValue());
+    }
+}

--- a/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashSet2DTest.java
+++ b/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashSet2DTest.java
@@ -3,8 +3,10 @@ package com.gtnewhorizon.gtnhlib.test.datastructs.space;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,11 +88,43 @@ class HashSet2DTest {
     }
 
     @Test
-    void fastEntryStreamCountMatchesSize() {
+    void slowIteratorReturnsIndependentInstances() {
         set.add(1, 2);
         set.add(3, 4);
 
-        assertEquals(2, set.fastEntryStream().count());
+        var iter = set.slowIterator();
+        XZAddressable first = iter.next();
+        assertTrue(iter.hasNext());
+        XZAddressable second = iter.next();
+
+        assertNotSame(first, second);
+        assertFalse(iter.hasNext());
+
+        Set<String> seen = new HashSet<>();
+        seen.add(first.getX() + "," + first.getZ());
+        seen.add(second.getX() + "," + second.getZ());
+        assertEquals(new HashSet<>(Arrays.asList("1,2", "3,4")), seen);
+    }
+
+    @Test
+    void slowStreamCountMatchesSize() {
+        set.add(1, 2);
+        set.add(3, 4);
+
+        assertEquals(2, set.slowStream().count());
+    }
+
+    @Test
+    void slowStreamElementsSurviveBuffering() {
+        set.add(1, 2);
+        set.add(3, 4);
+
+        // sorted() buffers every element before emitting; slowStream must not share mutable state
+        // across elements the way fastEntryStream() used to, or every entry would collapse to the last one.
+        Set<String> collected = set.slowStream().sorted(Comparator.comparingInt(XZAddressable::getX))
+                .map(e -> e.getX() + "," + e.getZ()).collect(Collectors.toCollection(HashSet::new));
+
+        assertEquals(new HashSet<>(Arrays.asList("1,2", "3,4")), collected);
     }
 
     @Test

--- a/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashSet2DTest.java
+++ b/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashSet2DTest.java
@@ -1,0 +1,105 @@
+package com.gtnewhorizon.gtnhlib.test.datastructs.space;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.gtnewhorizon.gtnhlib.datastructs.space.HashSet2D;
+import com.gtnewhorizon.gtnhlib.space.ImmutableXZ;
+import com.gtnewhorizon.gtnhlib.space.XZAddressable;
+
+class HashSet2DTest {
+
+    private HashSet2D set;
+
+    @BeforeEach
+    void setUp() {
+        set = new HashSet2D();
+    }
+
+    @Test
+    void addAndContainsByCoordinates() {
+        assertTrue(set.add(1, 2));
+        assertTrue(set.contains(1, 2));
+        assertFalse(set.contains(2, 1));
+    }
+
+    @Test
+    void addingSameCoordinatesTwiceReturnsFalse() {
+        assertTrue(set.add(1, 2));
+        assertFalse(set.add(1, 2));
+        assertEquals(1, set.size());
+    }
+
+    @Test
+    void addAndContainsByAddressable() {
+        ImmutableXZ pos = new ImmutableXZ(3, 4);
+        assertTrue(set.add(pos));
+        assertTrue(set.contains(pos));
+        assertTrue(set.contains(3, 4));
+    }
+
+    @Test
+    void removeByCoordinates() {
+        set.add(5, 6);
+        assertTrue(set.remove(5, 6));
+        assertFalse(set.contains(5, 6));
+        assertFalse(set.remove(5, 6));
+    }
+
+    @Test
+    void removeByAddressable() {
+        ImmutableXZ pos = new ImmutableXZ(7, 8);
+        set.add(pos);
+        assertTrue(set.remove(pos));
+        assertFalse(set.contains(pos));
+    }
+
+    @Test
+    void forEachVisitsAllCoordinates() {
+        set.add(1, 2);
+        set.add(3, 4);
+
+        Set<String> seen = new HashSet<>();
+        set.forEach((x, z) -> seen.add(x + "," + z));
+
+        assertEquals(new HashSet<>(Arrays.asList("1,2", "3,4")), seen);
+    }
+
+    @Test
+    void fastIteratorReusesSameMutableInstance() {
+        set.add(1, 2);
+        set.add(3, 4);
+
+        var iter = set.fastIterator();
+        XZAddressable first = iter.next();
+        assertTrue(iter.hasNext());
+        XZAddressable second = iter.next();
+
+        assertSame(first, second);
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    void fastEntryStreamCountMatchesSize() {
+        set.add(1, 2);
+        set.add(3, 4);
+
+        assertEquals(2, set.fastEntryStream().count());
+    }
+
+    @Test
+    void negativeCoordinatesAreDistinctFromPositive() {
+        set.add(-1, -2);
+        set.add(1, 2);
+
+        assertTrue(set.contains(-1, -2));
+        assertTrue(set.contains(1, 2));
+        assertEquals(2, set.size());
+    }
+}

--- a/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashSet3DTest.java
+++ b/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashSet3DTest.java
@@ -1,0 +1,105 @@
+package com.gtnewhorizon.gtnhlib.test.datastructs.space;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.gtnewhorizon.gtnhlib.datastructs.space.HashSet3D;
+import com.gtnewhorizon.gtnhlib.space.ImmutableXYZ;
+import com.gtnewhorizon.gtnhlib.space.XYZAddressable;
+
+class HashSet3DTest {
+
+    private HashSet3D set;
+
+    @BeforeEach
+    void setUp() {
+        set = new HashSet3D();
+    }
+
+    @Test
+    void addAndContainsByCoordinates() {
+        assertTrue(set.add(1, 2, 3));
+        assertTrue(set.contains(1, 2, 3));
+        assertFalse(set.contains(3, 2, 1));
+    }
+
+    @Test
+    void addingSameCoordinatesTwiceReturnsFalse() {
+        assertTrue(set.add(1, 2, 3));
+        assertFalse(set.add(1, 2, 3));
+        assertEquals(1, set.size());
+    }
+
+    @Test
+    void addAndContainsByAddressable() {
+        ImmutableXYZ pos = new ImmutableXYZ(3, 4, 5);
+        assertTrue(set.add(pos));
+        assertTrue(set.contains(pos));
+        assertTrue(set.contains(3, 4, 5));
+    }
+
+    @Test
+    void removeByCoordinates() {
+        set.add(5, 6, 7);
+        assertTrue(set.remove(5, 6, 7));
+        assertFalse(set.contains(5, 6, 7));
+        assertFalse(set.remove(5, 6, 7));
+    }
+
+    @Test
+    void removeByAddressable() {
+        ImmutableXYZ pos = new ImmutableXYZ(7, 8, 9);
+        set.add(pos);
+        assertTrue(set.remove(pos));
+        assertFalse(set.contains(pos));
+    }
+
+    @Test
+    void forEachVisitsAllCoordinates() {
+        set.add(1, 2, 3);
+        set.add(4, 5, 6);
+
+        Set<String> seen = new HashSet<>();
+        set.forEach((x, y, z) -> seen.add(x + "," + y + "," + z));
+
+        assertEquals(new HashSet<>(Arrays.asList("1,2,3", "4,5,6")), seen);
+    }
+
+    @Test
+    void fastIteratorReusesSameMutableInstance() {
+        set.add(1, 2, 3);
+        set.add(4, 5, 6);
+
+        var iter = set.fastIterator();
+        XYZAddressable first = iter.next();
+        assertTrue(iter.hasNext());
+        XYZAddressable second = iter.next();
+
+        assertSame(first, second);
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    void fastEntryStreamCountMatchesSize() {
+        set.add(1, 2, 3);
+        set.add(4, 5, 6);
+
+        assertEquals(2, set.fastEntryStream().count());
+    }
+
+    @Test
+    void negativeCoordinatesAreDistinctFromPositive() {
+        set.add(-1, -2, -3);
+        set.add(1, 2, 3);
+
+        assertTrue(set.contains(-1, -2, -3));
+        assertTrue(set.contains(1, 2, 3));
+        assertEquals(2, set.size());
+    }
+}

--- a/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashSet3DTest.java
+++ b/src/test/java/com/gtnewhorizon/gtnhlib/test/datastructs/space/HashSet3DTest.java
@@ -3,8 +3,10 @@ package com.gtnewhorizon.gtnhlib.test.datastructs.space;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,11 +88,43 @@ class HashSet3DTest {
     }
 
     @Test
-    void fastEntryStreamCountMatchesSize() {
+    void slowIteratorReturnsIndependentInstances() {
         set.add(1, 2, 3);
         set.add(4, 5, 6);
 
-        assertEquals(2, set.fastEntryStream().count());
+        var iter = set.slowIterator();
+        XYZAddressable first = iter.next();
+        assertTrue(iter.hasNext());
+        XYZAddressable second = iter.next();
+
+        assertNotSame(first, second);
+        assertFalse(iter.hasNext());
+
+        Set<String> seen = new HashSet<>();
+        seen.add(first.getX() + "," + first.getY() + "," + first.getZ());
+        seen.add(second.getX() + "," + second.getY() + "," + second.getZ());
+        assertEquals(new HashSet<>(Arrays.asList("1,2,3", "4,5,6")), seen);
+    }
+
+    @Test
+    void slowStreamCountMatchesSize() {
+        set.add(1, 2, 3);
+        set.add(4, 5, 6);
+
+        assertEquals(2, set.slowStream().count());
+    }
+
+    @Test
+    void slowStreamElementsSurviveBuffering() {
+        set.add(1, 2, 3);
+        set.add(4, 5, 6);
+
+        // sorted() buffers every element before emitting; slowStream must not share mutable state
+        // across elements the way fastEntryStream() used to, or every entry would collapse to the last one.
+        Set<String> collected = set.slowStream().sorted(Comparator.comparingInt(XYZAddressable::getX))
+                .map(e -> e.getX() + "," + e.getY() + "," + e.getZ()).collect(Collectors.toCollection(HashSet::new));
+
+        assertEquals(new HashSet<>(Arrays.asList("1,2,3", "4,5,6")), collected);
     }
 
     @Test


### PR DESCRIPTION
## Summary
This ports some fastutils-backed coordinate packing maps from Cubic Chunks. I've made similar collections in various other mods before, but these should be fully featured. These are useful because you can just put something at a specific X,Y,Z coordinate and fetch it later without needing to pack a key first.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
