### PR TITLE
Support bake item sprite

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/unbaked/JSONModel.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/unbaked/JSONModel.java
@@ -253,7 +253,8 @@ public class JSONModel implements UnbakedModel {
         name = name.replaceFirst("^minecraft:", "");
         var icon = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(name);
         if ("missingno".equals(icon.getIconName())) {
-            icon = ((TextureMap) Minecraft.getMinecraft().getTextureManager().getTexture(TextureMap.locationItemsTexture)).getAtlasSprite(name);
+            icon = ((TextureMap) Minecraft.getMinecraft().getTextureManager()
+                    .getTexture(TextureMap.locationItemsTexture)).getAtlasSprite(name);
         }
         final float minU = icon.getMinU();
         final float minV = icon.getMinV();

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/unbaked/JSONModel.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/unbaked/JSONModel.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -250,7 +251,10 @@ public class JSONModel implements UnbakedModel {
     // TODO Doesn't account for UV rotation settings atm
     protected void bakeSprite(ModelQuadViewMutable quad, String name) {
         name = name.replaceFirst("^minecraft:", "");
-        final var icon = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(name);
+        var icon = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(name);
+        if ("missingno".equals(icon.getIconName())) {
+            icon = ((TextureMap) Minecraft.getMinecraft().getTextureManager().getTexture(TextureMap.locationItemsTexture)).getAtlasSprite(name);
+        }
         final float minU = icon.getMinU();
         final float minV = icon.getMinV();
         final float dU = icon.getMaxU() - minU;


### PR DESCRIPTION
## Summary
When `JSONModel#bakeSprite` bakes a block's atlas sprite, if the `IIcon` is missingno, it will fall back to matching from `TextureMap.locationItemsTexture`.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge