### PR TITLE
Feat: Add opt-in ability for modded blocks to go in flower pots

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLibConfig.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLibConfig.java
@@ -13,6 +13,10 @@ public class GTNHLibConfig {
     @Config.DefaultBoolean(true)
     public static boolean enableFontRendererMixin;
 
+    @Config.Comment("Enable modded blocks to go into Flower Pots using IFlowerPottable")
+    @Config.DefaultBoolean(true)
+    public static boolean enableMoreFlowerPottage;
+
     @Config.Comment("Larger values take more RAM, but require less model rebuilding (may reduce lag spikes). Unless you are very short on RAM, reducing this is not advised.")
     @Config.DefaultInt(1000)
     @Config.RangeInt(min = 1, max = 1_000_000)

--- a/src/main/java/com/gtnewhorizon/gtnhlib/IFlowerPottable.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/IFlowerPottable.java
@@ -1,0 +1,44 @@
+package com.gtnewhorizon.gtnhlib;
+
+import java.util.ArrayList;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.IBlockAccess;
+
+// TODO dont leave this sitting around in the root package
+
+/**
+ * Allow this block to be placed into vanilla Flower Pots. If your block is simple and all of its standard ItemBlock
+ * textures will work in a flower pot, you don't need to override anything.
+ */
+public interface IFlowerPottable {
+
+    default boolean canBePotted(int meta) {
+        return true;
+    }
+
+    /**
+     * Write additional data to the NBT of the flower pot. This NBT can be accessed in
+     * {@link #renderFlowerPot(NBTTagCompound, IBlockAccess, Block, int, int, int, RenderBlocks)} (NBTTagCompound)} and
+     * {@link #breakFlowerPot(NBTTagCompound)}
+     */
+    default void writeToFlowerPotNBT(NBTTagCompound compound) {}
+
+    /**
+     * Override standard flower pot rendering. Return true if rendering was overriden!
+     */
+    default boolean renderFlowerPot(NBTTagCompound compound, IBlockAccess blockAccess, Block block, int x, int y, int z,
+            RenderBlocks render) {
+        return false;
+    }
+
+    /**
+     * Override the standard flower pot drops. Will drop the normal item if null is returned.
+     */
+    default ArrayList<ItemStack> breakFlowerPot(NBTTagCompound compound) {
+        return null;
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/IFlowerPottable.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/IFlowerPottable.java
@@ -21,7 +21,7 @@ public interface IFlowerPottable {
     /**
      * Write additional data to the NBT of the flower pot. This NBT can be accessed in
      * {@link #renderFlowerPot(NBTTagCompound, IBlockAccess, Block, int, int, int, RenderBlocks)} (NBTTagCompound)} and
-     * {@link #breakFlowerPot(NBTTagCompound)}
+     * {@link #addDropsToFlowerPot(NBTTagCompound)}
      */
     default void writeToFlowerPotNBT(NBTTagCompound compound) {}
 
@@ -36,7 +36,7 @@ public interface IFlowerPottable {
     /**
      * Override the standard flower pot drops. Will drop the normal item if null is returned.
      */
-    default ArrayList<ItemStack> breakFlowerPot(NBTTagCompound compound) {
+    default ArrayList<ItemStack> addDropsToFlowerPot(NBTTagCompound compound) {
         return null;
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/IFlowerPottable.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/IFlowerPottable.java
@@ -23,7 +23,7 @@ public interface IFlowerPottable {
      * {@link #renderFlowerPot(NBTTagCompound, IBlockAccess, Block, int, int, int, RenderBlocks)} (NBTTagCompound)} and
      * {@link #addDropsToFlowerPot(NBTTagCompound)}
      */
-    default void writeToFlowerPotNBT(NBTTagCompound compound) {}
+    default void writeToFlowerPotNBT(NBTTagCompound compound, int meta) {}
 
     /**
      * Override standard flower pot rendering. Return true if rendering was overriden!

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/IFlowerPottable.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/IFlowerPottable.java
@@ -1,4 +1,4 @@
-package com.gtnewhorizon.gtnhlib;
+package com.gtnewhorizon.gtnhlib.api;
 
 import java.util.ArrayList;
 
@@ -7,8 +7,6 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.IBlockAccess;
-
-// TODO dont leave this sitting around in the root package
 
 /**
  * Allow this block to be placed into vanilla Flower Pots. If your block is simple and all of its standard ItemBlock

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/IFlowerPottable.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/IFlowerPottable.java
@@ -1,7 +1,5 @@
 package com.gtnewhorizon.gtnhlib.api;
 
-import java.util.ArrayList;
-
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.item.ItemStack;
@@ -14,14 +12,14 @@ import net.minecraft.world.IBlockAccess;
  */
 public interface IFlowerPottable {
 
-    default boolean canBePotted(int meta) {
+    default boolean isFlowerPottable(int meta) {
         return true;
     }
 
     /**
      * Write additional data to the NBT of the flower pot. This NBT can be accessed in
      * {@link #renderFlowerPot(NBTTagCompound, IBlockAccess, Block, int, int, int, RenderBlocks)} (NBTTagCompound)} and
-     * {@link #addDropsToFlowerPot(NBTTagCompound)}
+     * {@link #replaceFlowerPotDrop(NBTTagCompound)}
      */
     default void writeToFlowerPotNBT(NBTTagCompound compound, int meta) {}
 
@@ -34,9 +32,10 @@ public interface IFlowerPottable {
     }
 
     /**
-     * Override the standard flower pot drops. Will drop the normal item if null is returned.
+     * Replace the flower drop from a flower pot containing this block. Will drop the default (a new ItemStack with just
+     * item id and meta) if this returns null.
      */
-    default ArrayList<ItemStack> addDropsToFlowerPot(NBTTagCompound compound) {
+    default ItemStack replaceFlowerPotDrop(NBTTagCompound compound) {
         return null;
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -62,6 +62,9 @@ public enum Mixins implements IMixins {
     WORLD_DELETION_EVENT(Side.CLIENT, "MixinGuiSelectWorld"),
     WORLD_LOAD_WARNING(new MixinBuilder("Accessors for the world conversion warning screen system")
             .addCommonMixins("AccessorGuiNotification", "AccessorStartupQuery").setPhase(Phase.EARLY)),
+    MODDED_FLOWERS_IN_FLOWER_POT(new MixinBuilder()
+            .addCommonMixins("MixinBlockFlowerPot", "MixinTileEntityFlowerPot", "MixinRenderBlocks_FlowerPot")
+            .setApplyIf(() -> GTNHLibConfig.enableMoreFlowerPottage).setPhase(Phase.EARLY)),
     //
     ;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinBlockFlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinBlockFlowerPot.java
@@ -1,0 +1,44 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import java.util.ArrayList;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockFlowerPot;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntityFlowerPot;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.gtnewhorizon.gtnhlib.IFlowerPottable;
+import com.llamalad7.mixinextras.sugar.Local;
+
+@Mixin(BlockFlowerPot.class)
+public class MixinBlockFlowerPot {
+
+    @Inject(method = "func_149928_a(Lnet/minecraft/block/Block;I)Z", at = @At(value = "HEAD"), cancellable = true)
+    private void gtnhlib$allowModdedFlowers(Block p_149928_1_, int p_149928_2_, CallbackInfoReturnable<Boolean> cir) {
+        if (p_149928_1_ instanceof IFlowerPottable pottable && pottable.canBePotted(p_149928_2_)) {
+            cir.setReturnValue(true);
+        }
+    }
+
+    @Inject(method = "getDrops", at = @At("RETURN"), remap = false, cancellable = true)
+    private void gtnhlib$customFlowerPotDrops(World world, int x, int y, int z, int metadata, int fortune,
+            CallbackInfoReturnable<ArrayList<ItemStack>> cir, @Local(name = "te") TileEntityFlowerPot te) {
+        if (te != null && te.getFlowerPotItem() instanceof IFlowerPottable pottable) {
+            NBTTagCompound compound = new NBTTagCompound();
+            te.writeToNBT(compound);
+
+            ArrayList<ItemStack> customDrop = pottable.breakFlowerPot(compound);
+
+            if (customDrop != null) {
+                cir.setReturnValue(customDrop);
+            }
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinBlockFlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinBlockFlowerPot.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.gtnewhorizon.gtnhlib.IFlowerPottable;
+import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
 import com.llamalad7.mixinextras.sugar.Local;
 
 @Mixin(BlockFlowerPot.class)

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinBlockFlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinBlockFlowerPot.java
@@ -11,6 +11,7 @@ import net.minecraft.tileentity.TileEntityFlowerPot;
 import net.minecraft.world.World;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -19,11 +20,14 @@ import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
 import com.llamalad7.mixinextras.sugar.Local;
 
 @Mixin(BlockFlowerPot.class)
-public class MixinBlockFlowerPot {
+public abstract class MixinBlockFlowerPot {
+
+    @Shadow
+    public abstract ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune);
 
     @Inject(method = "func_149928_a(Lnet/minecraft/block/Block;I)Z", at = @At(value = "HEAD"), cancellable = true)
-    private void gtnhlib$allowModdedFlowers(Block p_149928_1_, int p_149928_2_, CallbackInfoReturnable<Boolean> cir) {
-        if (p_149928_1_ instanceof IFlowerPottable pottable && pottable.canBePotted(p_149928_2_)) {
+    private void gtnhlib$allowModdedFlowers(Block block, int meta, CallbackInfoReturnable<Boolean> cir) {
+        if (block instanceof IFlowerPottable pottable && pottable.isFlowerPottable(meta)) {
             cir.setReturnValue(true);
         }
     }
@@ -31,18 +35,20 @@ public class MixinBlockFlowerPot {
     @Inject(method = "getDrops", at = @At("RETURN"), remap = false, cancellable = true)
     private void gtnhlib$customFlowerPotDrops(World world, int x, int y, int z, int metadata, int fortune,
             CallbackInfoReturnable<ArrayList<ItemStack>> cir, @Local(name = "te") TileEntityFlowerPot te) {
-        if (te != null) {
-            Item item = te.getFlowerPotItem();
-            if (Block.getBlockFromItem(item) instanceof IFlowerPottable pottable) {
-                NBTTagCompound compound = new NBTTagCompound();
-                te.writeToNBT(compound);
+        if (te == null) return;
+        Item item = te.getFlowerPotItem();
+        if (!(Block.getBlockFromItem(item) instanceof IFlowerPottable pottable)) return;
 
-                ArrayList<ItemStack> customDrop = pottable.addDropsToFlowerPot(compound);
+        NBTTagCompound compound = new NBTTagCompound();
+        te.writeToNBT(compound);
 
-                if (customDrop != null) {
-                    cir.setReturnValue(customDrop);
-                }
-            }
+        ItemStack customDrop = pottable.replaceFlowerPotDrop(compound);
+
+        if (customDrop != null) {
+            ArrayList<ItemStack> drops = cir.getReturnValue();
+            drops.remove(drops.size() - 1);
+            drops.add(customDrop);
+            cir.setReturnValue(drops);
         }
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinBlockFlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinBlockFlowerPot.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFlowerPot;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntityFlowerPot;
@@ -30,14 +31,17 @@ public class MixinBlockFlowerPot {
     @Inject(method = "getDrops", at = @At("RETURN"), remap = false, cancellable = true)
     private void gtnhlib$customFlowerPotDrops(World world, int x, int y, int z, int metadata, int fortune,
             CallbackInfoReturnable<ArrayList<ItemStack>> cir, @Local(name = "te") TileEntityFlowerPot te) {
-        if (te != null && te.getFlowerPotItem() instanceof IFlowerPottable pottable) {
-            NBTTagCompound compound = new NBTTagCompound();
-            te.writeToNBT(compound);
+        if (te != null) {
+            Item item = te.getFlowerPotItem();
+            if (Block.getBlockFromItem(item) instanceof IFlowerPottable pottable) {
+                NBTTagCompound compound = new NBTTagCompound();
+                te.writeToNBT(compound);
 
-            ArrayList<ItemStack> customDrop = pottable.breakFlowerPot(compound);
+                ArrayList<ItemStack> customDrop = pottable.breakFlowerPot(compound);
 
-            if (customDrop != null) {
-                cir.setReturnValue(customDrop);
+                if (customDrop != null) {
+                    cir.setReturnValue(customDrop);
+                }
             }
         }
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinBlockFlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinBlockFlowerPot.java
@@ -37,7 +37,7 @@ public class MixinBlockFlowerPot {
                 NBTTagCompound compound = new NBTTagCompound();
                 te.writeToNBT(compound);
 
-                ArrayList<ItemStack> customDrop = pottable.breakFlowerPot(compound);
+                ArrayList<ItemStack> customDrop = pottable.addDropsToFlowerPot(compound);
 
                 if (customDrop != null) {
                     cir.setReturnValue(customDrop);

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderBlocks_FlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderBlocks_FlowerPot.java
@@ -1,0 +1,55 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockFlowerPot;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.item.Item;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityFlowerPot;
+import net.minecraft.world.IBlockAccess;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.gtnewhorizon.gtnhlib.IFlowerPottable;
+import com.llamalad7.mixinextras.sugar.Local;
+
+@Mixin(RenderBlocks.class)
+public class MixinRenderBlocks_FlowerPot {
+
+    @Shadow
+    public IBlockAccess blockAccess;
+
+    @Inject(
+            method = "renderBlockFlowerpot",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/Block;getBlockFromItem(Lnet/minecraft/item/Item;)Lnet/minecraft/block/Block;"),
+            cancellable = true)
+    private void gtnhlib$renderCustomFlowerPot(BlockFlowerPot p_147752_1_, int p_147752_2_, int p_147752_3_,
+            int p_147752_4_, CallbackInfoReturnable<Boolean> cir, @Local(name = "tileentity") TileEntity tileentity) {
+
+        if (tileentity instanceof TileEntityFlowerPot te) {
+            Item item = te.getFlowerPotItem();
+            if (item instanceof IFlowerPottable pottable) {
+                NBTTagCompound compound = new NBTTagCompound();
+                te.writeToNBT(compound);
+
+                if (pottable.renderFlowerPot(
+                        compound,
+                        blockAccess,
+                        Block.getBlockFromItem(item),
+                        p_147752_2_,
+                        p_147752_3_,
+                        p_147752_4_,
+                        (RenderBlocks) (Object) this)) {
+                    cir.setReturnValue(true);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderBlocks_FlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderBlocks_FlowerPot.java
@@ -30,29 +30,21 @@ public class MixinRenderBlocks_FlowerPot {
                     value = "INVOKE",
                     target = "Lnet/minecraft/block/Block;getBlockFromItem(Lnet/minecraft/item/Item;)Lnet/minecraft/block/Block;"),
             cancellable = true)
-    private void gtnhlib$renderCustomFlowerPot(BlockFlowerPot p_147752_1_, int p_147752_2_, int p_147752_3_,
-            int p_147752_4_, CallbackInfoReturnable<Boolean> cir, @Local(name = "tileentity") TileEntity tileentity) {
+    private void gtnhlib$renderCustomFlowerPot(BlockFlowerPot blockPot, int x, int y, int z,
+            CallbackInfoReturnable<Boolean> cir, @Local(name = "tileentity") TileEntity tileentity) {
+        if (!(tileentity instanceof TileEntityFlowerPot pot)) return;
 
-        if (tileentity instanceof TileEntityFlowerPot te) {
-            Item item = te.getFlowerPotItem();
-            if (item != null) {
-                Block block = Block.getBlockFromItem(item);
-                if (block instanceof IFlowerPottable pottable) {
-                    NBTTagCompound compound = new NBTTagCompound();
-                    te.writeToNBT(compound);
+        Item item = pot.getFlowerPotItem();
+        if (item == null) return;
 
-                    if (pottable.renderFlowerPot(
-                            compound,
-                            blockAccess,
-                            block,
-                            p_147752_2_,
-                            p_147752_3_,
-                            p_147752_4_,
-                            (RenderBlocks) (Object) this)) {
-                        cir.setReturnValue(true);
-                    }
-                }
-            }
+        Block block = Block.getBlockFromItem(item);
+        if (!(block instanceof IFlowerPottable pottable)) return;
+
+        NBTTagCompound compound = new NBTTagCompound();
+        pot.writeToNBT(compound);
+
+        if (pottable.renderFlowerPot(compound, blockAccess, block, x, y, z, (RenderBlocks) (Object) this)) {
+            cir.setReturnValue(true);
         }
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderBlocks_FlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderBlocks_FlowerPot.java
@@ -35,19 +35,22 @@ public class MixinRenderBlocks_FlowerPot {
 
         if (tileentity instanceof TileEntityFlowerPot te) {
             Item item = te.getFlowerPotItem();
-            if (item instanceof IFlowerPottable pottable) {
-                NBTTagCompound compound = new NBTTagCompound();
-                te.writeToNBT(compound);
+            if (item != null) {
+                Block block = Block.getBlockFromItem(item);
+                if (block instanceof IFlowerPottable pottable) {
+                    NBTTagCompound compound = new NBTTagCompound();
+                    te.writeToNBT(compound);
 
-                if (pottable.renderFlowerPot(
-                        compound,
-                        blockAccess,
-                        Block.getBlockFromItem(item),
-                        p_147752_2_,
-                        p_147752_3_,
-                        p_147752_4_,
-                        (RenderBlocks) (Object) this)) {
-                    cir.setReturnValue(true);
+                    if (pottable.renderFlowerPot(
+                            compound,
+                            blockAccess,
+                            block,
+                            p_147752_2_,
+                            p_147752_3_,
+                            p_147752_4_,
+                            (RenderBlocks) (Object) this)) {
+                        cir.setReturnValue(true);
+                    }
                 }
             }
         }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderBlocks_FlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderBlocks_FlowerPot.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.gtnewhorizon.gtnhlib.IFlowerPottable;
+import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
 import com.llamalad7.mixinextras.sugar.Local;
 
 @Mixin(RenderBlocks.class)

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import com.gtnewhorizon.gtnhlib.IFlowerPottable;
+import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
 
 @Mixin(TileEntityFlowerPot.class)
 public class MixinTileEntityFlowerPot {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizon.gtnhlib.mixins.early;
 
+import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntityFlowerPot;
@@ -20,7 +21,7 @@ public class MixinTileEntityFlowerPot {
 
     @Inject(method = "writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("TAIL"))
     private void hodgepodge$writeFlowerPottableNBT(NBTTagCompound compound, CallbackInfo ci) {
-        if (flowerPotItem instanceof IFlowerPottable pottable) {
+        if (Block.getBlockFromItem(flowerPotItem) instanceof IFlowerPottable pottable) {
             pottable.writeToFlowerPotNBT(compound);
         }
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
@@ -1,0 +1,27 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import net.minecraft.item.Item;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntityFlowerPot;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizon.gtnhlib.IFlowerPottable;
+
+@Mixin(TileEntityFlowerPot.class)
+public class MixinTileEntityFlowerPot {
+
+    @Shadow
+    private Item flowerPotItem;
+
+    @Inject(method = "writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("TAIL"))
+    private void hodgepodge$writeFlowerPottableNBT(NBTTagCompound compound, CallbackInfo ci) {
+        if (flowerPotItem instanceof IFlowerPottable pottable) {
+            pottable.writeToFlowerPotNBT(compound);
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
@@ -23,14 +23,14 @@ public class MixinTileEntityFlowerPot {
     private int flowerPotData;
 
     @Inject(method = "writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("TAIL"))
-    private void hodgepodge$writeFlowerPottableNBT(NBTTagCompound compound, CallbackInfo ci) {
+    private void gtnhlib$writeFlowerPottableNBT(NBTTagCompound compound, CallbackInfo ci) {
         if (Block.getBlockFromItem(flowerPotItem) instanceof IFlowerPottable pottable) {
             pottable.writeToFlowerPotNBT(compound, flowerPotData);
         }
     }
 
     @Inject(method = "readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("TAIL"), remap = false)
-    private void hodgepodge$updateOnRead(NBTTagCompound compound, CallbackInfo ci) {
+    private void gtnhlib$updateOnRead(NBTTagCompound compound, CallbackInfo ci) {
         TileEntityFlowerPot te = ((TileEntityFlowerPot) (Object) this);
         World world = te.getWorldObj();
         if (world != null && world.isRemote) {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
@@ -19,11 +19,13 @@ public class MixinTileEntityFlowerPot {
 
     @Shadow
     private Item flowerPotItem;
+    @Shadow
+    private int flowerPotData;
 
     @Inject(method = "writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("TAIL"))
     private void hodgepodge$writeFlowerPottableNBT(NBTTagCompound compound, CallbackInfo ci) {
         if (Block.getBlockFromItem(flowerPotItem) instanceof IFlowerPottable pottable) {
-            pottable.writeToFlowerPotNBT(compound);
+            pottable.writeToFlowerPotNBT(compound, flowerPotData);
         }
     }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinTileEntityFlowerPot.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntityFlowerPot;
+import net.minecraft.world.World;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,6 +24,15 @@ public class MixinTileEntityFlowerPot {
     private void hodgepodge$writeFlowerPottableNBT(NBTTagCompound compound, CallbackInfo ci) {
         if (Block.getBlockFromItem(flowerPotItem) instanceof IFlowerPottable pottable) {
             pottable.writeToFlowerPotNBT(compound);
+        }
+    }
+
+    @Inject(method = "readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("TAIL"), remap = false)
+    private void hodgepodge$updateOnRead(NBTTagCompound compound, CallbackInfo ci) {
+        TileEntityFlowerPot te = ((TileEntityFlowerPot) (Object) this);
+        World world = te.getWorldObj();
+        if (world != null && world.isRemote) {
+            world.markBlockForUpdate(te.xCoord, te.yCoord, te.zCoord);
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds an interface IFlowerPottable that will allow any block to go into a flower pot. IFlowerPottable has a handful of useful methods for custom handling for blocks that need it. You can add additional NBT data to the flower pot TE and that additional data is accessible to the render and drop overload.

Summary of mixins:

gtnhlib$allowModdedFlowers: Mixin to big boolean chain of allowed vanilla blocks to also allow placement if the block is IFlowerPottable.

gtnhlib$customFlowerPotDrops: Call addDropsToFlowerPot during getDrops and allow replacing the items if needed.

gtnhlib$renderCustomFlowerPot: Pass a bunch of render information to the implementer so they can cancel the original rendering and replace it.

gtnhlib$writeFlowerPottableNBT: Allow implementer to add whatever NBT data they want to the TE.

gtnhlib$updateOnRead: Trigger a block update whenever the NBT is read on the client. This gets around the frankly insane way that flower pots are created on the client, without this, modded blocks will turn into random vanilla flowers.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
