### PR TITLE
Add BOP compat for flower pots

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -56,6 +56,7 @@ dependencies {
     compileOnly(rfg.deobf('curse.maven:minefactory-reloaded-66672:2366150')) { transitive = false }
     compileOnly(rfg.deobf("curse.maven:cofh-core-69162:2388751")) { transitive = false }
 
+    compileOnly(rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612"))
 
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {transitive = false}
 //    devOnlyNonPublishable('com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev') {transitive = false} // For testing Thaumcraft

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -65,6 +65,16 @@ public enum Mixins implements IMixins {
     MODDED_FLOWERS_IN_FLOWER_POT(new MixinBuilder()
             .addCommonMixins("MixinBlockFlowerPot", "MixinTileEntityFlowerPot", "MixinRenderBlocks_FlowerPot")
             .setApplyIf(() -> GTNHLibConfig.enableMoreFlowerPottage).setPhase(Phase.EARLY)),
+    BIOMES_O_PLENTY_FLOWER_POT(new MixinBuilder("Implement IFlowerPottable on BoP blocks")
+            .setApplyIf(() -> GTNHLibConfig.enableMoreFlowerPottage).setPhase(Phase.LATE)
+            .addCommonMixins(
+                    "flowerpotcompat.MixinBOPColorizedSapling",
+                    "flowerpotcompat.MixinBOPSapling",
+                    "flowerpotcompat.MixinBOPFlower",
+                    "flowerpotcompat.MixinBOPFlower2",
+                    "flowerpotcompat.MixinBOPPlant",
+                    "flowerpotcompat.MixinBOPMushroom")
+            .addRequiredMod(TargetMods.BIOMES_O_PLENTY)),
     //
     ;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/TargetMods.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/TargetMods.java
@@ -8,7 +8,8 @@ import com.gtnewhorizon.gtnhmixins.builders.TargetModBuilder;
 public enum TargetMods implements ITargetMod {
 
     LWJGL3IFY("me.eigenraven.lwjgl3ify.core.Lwjgl3ifyCoremod"),
-    THAUMCRAFT("", "Thaumcraft");
+    THAUMCRAFT("", "Thaumcraft"),
+    BIOMES_O_PLENTY("biomesoplenty.BiomesOPlenty", "BiomesOPlenty");
 
     private final TargetModBuilder builder;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPColorizedSapling.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPColorizedSapling.java
@@ -1,0 +1,15 @@
+package com.gtnewhorizon.gtnhlib.mixins.late.flowerpotcompat;
+
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
+
+import biomesoplenty.common.blocks.BlockBOPColorizedSapling;
+
+@Mixin(value = BlockBOPColorizedSapling.class, remap = false)
+@Implements(@Interface(iface = IFlowerPottable.class, prefix = "gtnhlib$"))
+public class MixinBOPColorizedSapling {
+
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPFlower.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPFlower.java
@@ -21,6 +21,7 @@ public class MixinBOPFlower {
 
     public boolean gtnhlib$isFlowerPottable(int meta) {
         // These ones don't work well, they clip way too badly or are flat on the ground
+        // Clover, Swampflower, Violet, White Anemone
         return (meta != 0 && meta != 1 && meta != 8 && meta != 9);
     }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPFlower.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPFlower.java
@@ -1,0 +1,49 @@
+package com.gtnewhorizon.gtnhlib.mixins.late.flowerpotcompat;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.IBlockAccess;
+
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
+
+import biomesoplenty.common.blocks.BlockBOPFlower;
+
+@Mixin(value = BlockBOPFlower.class, remap = false)
+@Implements(@Interface(iface = IFlowerPottable.class, prefix = "gtnhlib$"))
+public class MixinBOPFlower {
+
+    public boolean gtnhlib$isFlowerPottable(int meta) {
+        // These ones don't work well, they clip way too badly or are flat on the ground
+        return (meta != 0 && meta != 1 && meta != 8 && meta != 9);
+    }
+
+    public boolean gtnhlib$renderFlowerPot(NBTTagCompound compound, IBlockAccess blockAccess, Block block, int x, int y,
+            int z, RenderBlocks render) {
+        Tessellator tess = Tessellator.instance;
+        tess.addTranslation(0, 4F / 16F, 0);
+        render.drawCrossedSquares(
+                block.getIcon(blockAccess, x, y, z, 0),
+                x,
+                y,
+                z,
+                getScale(blockAccess.getBlockMetadata(x, y, z)));
+        tess.addTranslation(0, -4F / 16F, 0);
+        return true;
+    }
+
+    @Unique
+    private float getScale(int meta) {
+        return switch (meta) {
+            case 4 -> 0.7F;
+            case 11, 12 -> 0.45F;
+            default -> 0.75F;
+        };
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPFlower2.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPFlower2.java
@@ -1,0 +1,50 @@
+package com.gtnewhorizon.gtnhlib.mixins.late.flowerpotcompat;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.IBlockAccess;
+
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
+
+import biomesoplenty.common.blocks.BlockBOPFlower2;
+
+@Mixin(value = BlockBOPFlower2.class, remap = false)
+@Implements(@Interface(iface = IFlowerPottable.class, prefix = "gtnhlib$"))
+public class MixinBOPFlower2 {
+
+    public boolean gtnhlib$isFlowerPottable(int meta) {
+        // These ones don't work well, they clip way too badly
+        return (meta != 1 && meta != 5);
+    }
+
+    public boolean gtnhlib$renderFlowerPot(NBTTagCompound compound, IBlockAccess blockAccess, Block block, int x, int y,
+            int z, RenderBlocks render) {
+        Tessellator tess = Tessellator.instance;
+        tess.addTranslation(0, 4F / 16F, 0);
+        render.drawCrossedSquares(
+                block.getIcon(blockAccess, x, y, z, 0),
+                x,
+                y,
+                z,
+                getScale(blockAccess.getBlockMetadata(x, y, z)));
+        tess.addTranslation(0, -4F / 16F, 0);
+        return true;
+    }
+
+    @Unique
+    private float getScale(int meta) {
+        return switch (meta) {
+            case 2 -> 0.55F;
+            case 3 -> 0.65F;
+            case 7 -> 0.65F;
+            default -> 0.75F;
+        };
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPFlower2.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPFlower2.java
@@ -21,6 +21,7 @@ public class MixinBOPFlower2 {
 
     public boolean gtnhlib$isFlowerPottable(int meta) {
         // These ones don't work well, they clip way too badly
+        // Lily of the Valley, Bluebells
         return (meta != 1 && meta != 5);
     }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPMushroom.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPMushroom.java
@@ -20,6 +20,7 @@ public class MixinBOPMushroom {
 
     public boolean gtnhlib$isFlowerPottable(int meta) {
         // These ones don't work well, they clip way too badly
+        // Glowshroom, Shadow Shroom
         return (meta != 3 && meta != 5);
     }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPMushroom.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPMushroom.java
@@ -1,0 +1,34 @@
+package com.gtnewhorizon.gtnhlib.mixins.late.flowerpotcompat;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.IBlockAccess;
+
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
+
+import biomesoplenty.common.blocks.BlockBOPMushroom;
+
+@Mixin(value = BlockBOPMushroom.class, remap = false)
+@Implements(@Interface(iface = IFlowerPottable.class, prefix = "gtnhlib$"))
+public class MixinBOPMushroom {
+
+    public boolean gtnhlib$isFlowerPottable(int meta) {
+        // These ones don't work well, they clip way too badly
+        return (meta != 3 && meta != 5);
+    }
+
+    public boolean gtnhlib$renderFlowerPot(NBTTagCompound compound, IBlockAccess blockAccess, Block block, int x, int y,
+            int z, RenderBlocks render) {
+        Tessellator tess = Tessellator.instance;
+        tess.addTranslation(0, 4F / 16F, 0);
+        render.drawCrossedSquares(block.getIcon(blockAccess, x, y, z, 0), x, y, z, 0.75F);
+        tess.addTranslation(0, -4F / 16F, 0);
+        return true;
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPPlant.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPPlant.java
@@ -1,0 +1,34 @@
+package com.gtnewhorizon.gtnhlib.mixins.late.flowerpotcompat;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.IBlockAccess;
+
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
+
+import biomesoplenty.common.blocks.BlockBOPPlant;
+
+@Mixin(value = BlockBOPPlant.class, remap = false)
+@Implements(@Interface(iface = IFlowerPottable.class, prefix = "gtnhlib$"))
+public class MixinBOPPlant {
+
+    public boolean gtnhlib$isFlowerPottable(int meta) {
+        // I just wanted tiny cactus, thorns work well too
+        return (meta == 5 || meta == 12);
+    }
+
+    public boolean gtnhlib$renderFlowerPot(NBTTagCompound compound, IBlockAccess blockAccess, Block block, int x, int y,
+            int z, RenderBlocks render) {
+        Tessellator tess = Tessellator.instance;
+        tess.addTranslation(0, 4F / 16F, 0);
+        render.drawCrossedSquares(block.getIcon(blockAccess, x, y, z, 0), x, y, z, 0.75F);
+        tess.addTranslation(0, -4F / 16F, 0);
+        return true;
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPSapling.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/late/flowerpotcompat/MixinBOPSapling.java
@@ -1,0 +1,15 @@
+package com.gtnewhorizon.gtnhlib.mixins.late.flowerpotcompat;
+
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
+
+import biomesoplenty.common.blocks.BlockBOPSapling;
+
+@Mixin(value = BlockBOPSapling.class, remap = false)
+@Implements(@Interface(iface = IFlowerPottable.class, prefix = "gtnhlib$"))
+public class MixinBOPSapling {
+
+}


### PR DESCRIPTION
## Summary
Adds a bunch of mixins to force IFlowerPottable compat for BOP. I tweaked some of the scales for plants to make some that were on the verge of fitting well work.

<img width="759" height="292" alt="image" src="https://github.com/user-attachments/assets/880d59d4-73f5-4bcd-8edd-7d2d5b3bad45" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
