### PR TITLE
Fix world leak caused by PlayerInventoryEventHandler

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventhandlers/PlayerInventoryEventHandler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventhandlers/PlayerInventoryEventHandler.java
@@ -54,7 +54,12 @@ public final class PlayerInventoryEventHandler {
             states.put(id, state);
         }
 
-        PlayerInventoryScanner.process(player, state, client ? CLIENT_POSTER : SERVER_POSTER);
+        final InventoryEventPoster poster = client ? CLIENT_POSTER : SERVER_POSTER;
+        try {
+            PlayerInventoryScanner.process(player, state, poster);
+        } finally {
+            poster.player = null;
+        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

<img width="617" height="96" alt="image" src="https://github.com/user-attachments/assets/5980665b-e35c-4fb2-b262-df344dc41e9e" />
<img width="623" height="89" alt="image" src="https://github.com/user-attachments/assets/27c6074d-f0d8-4c15-a763-b458aba2cc3c" />


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
