### PR TITLE
Use Angelica/Celeritas AO when Angelica is present

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -42,7 +42,7 @@ dependencies {
     }
 
     // Annotation things
-    compileOnly("com.github.GTNewHorizons:Angelica:2.1.60:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Angelica:99.0.0:dev") { transitive = false }
     compileOnly('org.jetbrains:annotations:26.0.1')
     compileOnly("org.projectlombok:lombok:1.18.36") {transitive = false }
     annotationProcessor("org.projectlombok:lombok:1.18.36")

--- a/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
@@ -2,7 +2,6 @@ package com.gtnewhorizon.gtnhlib;
 
 import static com.gtnewhorizon.gtnhlib.core.GTNHLibCore.isObf;
 
-import com.gtnewhorizon.gtnhlib.test.block.BlockLightUnderStair;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.launchwrapper.Launch;
@@ -34,6 +33,7 @@ import com.gtnewhorizon.gtnhlib.network.PacketMessageAboveHotbar;
 import com.gtnewhorizon.gtnhlib.network.PacketViewDistance;
 import com.gtnewhorizon.gtnhlib.teams.TeamAdminCommand;
 import com.gtnewhorizon.gtnhlib.teams.TeamCommand;
+import com.gtnewhorizon.gtnhlib.test.block.BlockLightUnderStair;
 import com.gtnewhorizon.gtnhlib.test.block.BlockRngTest;
 import com.gtnewhorizon.gtnhlib.test.block.BlockTest;
 import com.gtnewhorizon.gtnhlib.test.block.BlockTestLectern;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
@@ -2,6 +2,7 @@ package com.gtnewhorizon.gtnhlib;
 
 import static com.gtnewhorizon.gtnhlib.core.GTNHLibCore.isObf;
 
+import com.gtnewhorizon.gtnhlib.test.block.BlockLightUnderStair;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.launchwrapper.Launch;
@@ -69,6 +70,7 @@ public class CommonProxy {
         GTNHLib.info("GTNHLib version " + Tags.VERSION + " loaded.");
 
         if (GTNHLibConfig.enableTestBlocks) {
+            BlockLightUnderStair.register();
             BlockTest.register();
             BlockTestLectern.register();
             BlockTestTint.register();

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/AngelicaHelper.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/AngelicaHelper.java
@@ -1,0 +1,27 @@
+package com.gtnewhorizon.gtnhlib.client.model;
+
+import com.gtnewhorizons.angelica.rendering.StateAwareTessellator;
+import net.minecraft.client.renderer.Tessellator;
+
+class AngelicaHelper {
+    /// This method doesn't need to mess with [com.gtnewhorizons.angelica.api.ExtCeleritasRenderBlocks] because that
+    /// only affects [net.minecraft.client.renderer.RenderBlocks] methods, which we don't use.
+    static void initAngelicaLighting(Tessellator tesselator) {
+        if (!(tesselator instanceof StateAwareTessellator saTess)) return;
+
+        saTess.angelica$setAppliedAo(true);
+    }
+
+    static void quadAngelicaLighting(Tessellator tesselator, boolean noDirectionalShading) {
+        if (!(tesselator instanceof StateAwareTessellator saTess)) return;
+
+        saTess.angelica$setNoDirectionalShading(noDirectionalShading);
+    }
+
+    static void resetAngelicaLighting(Tessellator tesselator) {
+        if (!(tesselator instanceof StateAwareTessellator saTess)) return;
+
+        saTess.angelica$setAppliedAo(false);
+        saTess.angelica$setNoDirectionalShading(false);
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/AngelicaHelper.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/AngelicaHelper.java
@@ -1,9 +1,11 @@
 package com.gtnewhorizon.gtnhlib.client.model;
 
-import com.gtnewhorizons.angelica.rendering.StateAwareTessellator;
 import net.minecraft.client.renderer.Tessellator;
 
+import com.gtnewhorizons.angelica.rendering.StateAwareTessellator;
+
 class AngelicaHelper {
+
     /// This method doesn't need to mess with [com.gtnewhorizons.angelica.api.ExtCeleritasRenderBlocks] because that
     /// only affects [net.minecraft.client.renderer.RenderBlocks] methods, which we don't use.
     static void initAngelicaLighting(Tessellator tesselator) {

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/ModelISBRH.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/ModelISBRH.java
@@ -5,6 +5,7 @@ import static com.gtnewhorizon.gtnhlib.client.renderer.cel.api.util.NormI8.unpac
 import static com.gtnewhorizon.gtnhlib.client.renderer.cel.api.util.NormI8.unpackZ;
 import static com.gtnewhorizon.gtnhlib.client.renderer.cel.model.quad.properties.ModelQuadFacing.DIRECTIONS;
 import static com.gtnewhorizon.gtnhlib.client.renderer.cel.model.quad.properties.ModelQuadFacing.VALUES;
+import static com.gtnewhorizon.gtnhlib.compat.Mods.ANGELICA;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.max;
 import static net.minecraftforge.client.IItemRenderer.ItemRenderType.ENTITY;
@@ -70,6 +71,7 @@ public class ModelISBRH implements ISimpleBlockRenderingHandler, IItemRenderer {
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId,
             RenderBlocks renderer) {
         final Tessellator tesselator = TessellatorManager.get();
+        if (ANGELICA) AngelicaHelper.initAngelicaLighting(tesselator);
 
         // Get the model!
         final int meta = world.getBlockMetadata(x, y, z);
@@ -115,11 +117,20 @@ public class ModelISBRH implements ISimpleBlockRenderingHandler, IItemRenderer {
                 final int lm = getLightMap(block, quad, quad.getLightFace(), world, x, y, z, renderer);
                 tesselator.setBrightness(lm);
 
-                final float shade = quad.hasDirectionalShading() ? diffuseLight(quad.getComputedFaceNormal()) : 1;
+                final float shade;
+                if (!ANGELICA) {
+                    shade = quad.hasDirectionalShading() ? diffuseLight(quad.getComputedFaceNormal()) : 1;
+                } else {
+                    AngelicaHelper.quadAngelicaLighting(tesselator, !quad.hasDirectionalShading());
+                    shade = 1;
+                }
+
                 tesselator.setColorOpaque_F(r * shade, g * shade, b * shade);
                 renderQuad(quad, x, y, z, tesselator, renderer.overrideBlockTexture);
             }
         }
+
+        if (ANGELICA) AngelicaHelper.resetAngelicaLighting(tesselator);
         worldContext.reset();
         return rendered;
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/cel/model/quad/ModelQuadView.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/cel/model/quad/ModelQuadView.java
@@ -67,11 +67,9 @@ public interface ModelQuadView extends ModelPrimitiveView {
      */
     boolean isTransparent();
 
-    /**
-     * Not to be confused with ambient occlusion AKA smooth lighting When true, allows this quad to multiply its
-     * brightness based on the direction it's facing. When this is false, each face derives its brightness directly from
-     * the light value it's facing without multiplying it.
-     */
+    /// Not to be confused with ambient occlusion AKA smooth lighting. When true, allows this quad to multiply its
+    /// brightness based on the direction it's facing. When this is false, each face derives its brightness directly from
+    /// the light value it's facing without multiplying it.
     boolean hasDirectionalShading();
 
     /**

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/cel/model/quad/ModelQuadView.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/cel/model/quad/ModelQuadView.java
@@ -68,7 +68,8 @@ public interface ModelQuadView extends ModelPrimitiveView {
     boolean isTransparent();
 
     /// Not to be confused with ambient occlusion AKA smooth lighting. When true, allows this quad to multiply its
-    /// brightness based on the direction it's facing. When this is false, each face derives its brightness directly from
+    /// brightness based on the direction it's facing. When this is false, each face derives its brightness directly
+    /// from
     /// the light value it's facing without multiplying it.
     boolean hasDirectionalShading();
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/test/block/BlockLightUnderStair.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/test/block/BlockLightUnderStair.java
@@ -1,0 +1,43 @@
+package com.gtnewhorizon.gtnhlib.test.block;
+
+import com.gtnewhorizon.gtnhlib.blockstate.properties.DirectionBlockProperty;
+import com.gtnewhorizon.gtnhlib.blockstate.properties.DirectionBlockProperty.AbstractDirectionBlockProperty;
+import com.gtnewhorizon.gtnhlib.blockstate.registry.BlockPropertyRegistry;
+import com.gtnewhorizon.gtnhlib.util.DirectionUtil;
+import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class BlockLightUnderStair extends Block {
+
+    public final AbstractDirectionBlockProperty FACING_PROP = (AbstractDirectionBlockProperty) DirectionBlockProperty
+            .facing();
+
+    public BlockLightUnderStair() {
+        super(Material.wood);
+    }
+
+    public static void register() {
+        final var testBlock = new BlockLightUnderStair();
+        testBlock.setBlockName("light_under_stair");
+        GameRegistry.registerBlock(testBlock, "light_under_stair");
+
+        BlockPropertyRegistry.registerBlockItemProperty(testBlock, testBlock.FACING_PROP, ForgeDirection.EAST);
+    }
+
+    @Override
+    public boolean isOpaqueCube() {
+        return false;
+    }
+
+    @Override
+    public void onBlockPlacedBy(World worldIn, int x, int y, int z, EntityLivingBase placer, ItemStack itemIn) {
+        var dir = DirectionUtil.yawToDirection(placer.rotationYaw);
+
+        worldIn.setBlockMetadataWithNotify(x, y, z, FACING_PROP.getMeta(dir, 0), 2);
+    }
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/test/block/BlockLightUnderStair.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/test/block/BlockLightUnderStair.java
@@ -1,16 +1,18 @@
 package com.gtnewhorizon.gtnhlib.test.block;
 
-import com.gtnewhorizon.gtnhlib.blockstate.properties.DirectionBlockProperty;
-import com.gtnewhorizon.gtnhlib.blockstate.properties.DirectionBlockProperty.AbstractDirectionBlockProperty;
-import com.gtnewhorizon.gtnhlib.blockstate.registry.BlockPropertyRegistry;
-import com.gtnewhorizon.gtnhlib.util.DirectionUtil;
-import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
+
+import com.gtnewhorizon.gtnhlib.blockstate.properties.DirectionBlockProperty;
+import com.gtnewhorizon.gtnhlib.blockstate.properties.DirectionBlockProperty.AbstractDirectionBlockProperty;
+import com.gtnewhorizon.gtnhlib.blockstate.registry.BlockPropertyRegistry;
+import com.gtnewhorizon.gtnhlib.util.DirectionUtil;
+
+import cpw.mods.fml.common.registry.GameRegistry;
 
 public class BlockLightUnderStair extends Block {
 

--- a/src/main/resources/assets/gtnhlib/blockstates/light_under_stair.json
+++ b/src/main/resources/assets/gtnhlib/blockstates/light_under_stair.json
@@ -1,0 +1,8 @@
+{
+  "variants": {
+    "facing=north": { "model": "gtnhlib:blocks/light_test_stairs", "y": 270, "uvlock": true },
+    "facing=south": { "model": "gtnhlib:blocks/light_test_stairs", "y": 90, "uvlock": true },
+    "facing=west": { "model": "gtnhlib:blocks/light_test_stairs", "y": 0, "uvlock": true },
+    "facing=east": { "model": "gtnhlib:blocks/light_test_stairs", "y": 180, "uvlock": true }
+  }
+}

--- a/src/main/resources/assets/gtnhlib/lang/en_US.lang
+++ b/src/main/resources/assets/gtnhlib/lang/en_US.lang
@@ -1,4 +1,5 @@
 # Test block names
+tile.light_under_stair.name=Directional Shading Test Block
 tile.model_test.name=Test Block
 tile.model_test_tint.name=Test Block (Tint)
 tile.model_test_tint_mul.name=Test Block (Tint Mul)

--- a/src/main/resources/assets/gtnhlib/models/blocks/light_test_stairs.json
+++ b/src/main/resources/assets/gtnhlib/models/blocks/light_test_stairs.json
@@ -1,0 +1,8 @@
+{
+  "parent": "gtnhlib:blocks/light_under_stair",
+  "textures": {
+    "bottom": "minecraft:planks_oak",
+    "side": "minecraft:planks_oak",
+    "top": "minecraft:planks_oak"
+  }
+}

--- a/src/main/resources/assets/gtnhlib/models/blocks/light_under_stair.json
+++ b/src/main/resources/assets/gtnhlib/models/blocks/light_under_stair.json
@@ -1,0 +1,49 @@
+{
+  "parent": "block/block",
+  "display": {
+    "gui": {
+      "rotation": [ 30, 135, 0 ],
+      "translation": [ 0, 0, 0],
+      "scale":[ 0.625, 0.625, 0.625 ]
+    },
+    "head": {
+      "rotation": [ 0, -90, 0 ],
+      "translation": [ 0, 0, 0 ],
+      "scale": [ 1, 1, 1 ]
+    },
+    "thirdperson_lefthand": {
+      "rotation": [ 75, -135, 0 ],
+      "translation": [ 0, 2.5, 0],
+      "scale": [ 0.375, 0.375, 0.375 ]
+    }
+  },
+  "textures": {
+    "particle": "#side"
+  },
+  "elements": [
+    {
+      "from": [ 0, 0, 0 ],
+      "to": [ 16, 8, 16 ],
+      "faces": {
+        "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
+        "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#top" },
+        "north": { "uv": [ 0, 8, 16, 16 ], "texture": "#side", "cullface": "north" },
+        "south": { "uv": [ 0, 8, 16, 16 ], "texture": "#side", "cullface": "south" },
+        "west":  { "uv": [ 0, 8, 16, 16 ], "texture": "#side", "cullface": "west" },
+        "east":  { "uv": [ 0, 8, 16, 16 ], "texture": "#side", "cullface": "east" }
+      },
+      "shade": false
+    },
+    {
+      "from": [ 8, 8, 0 ],
+      "to": [ 16, 16, 16 ],
+      "faces": {
+        "up":    { "uv": [ 8, 0, 16, 16 ], "texture": "#top", "cullface": "up" },
+        "north": { "uv": [ 0, 0,  8,  8 ], "texture": "#side", "cullface": "north" },
+        "south": { "uv": [ 8, 0, 16,  8 ], "texture": "#side", "cullface": "south" },
+        "west":  { "uv": [ 0, 0, 16,  8 ], "texture": "#side" },
+        "east":  { "uv": [ 0, 0, 16,  8 ], "texture": "#side", "cullface": "east" }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
What it says in the title. After many attempts, I was unable to produce anything as good as Celeritas and I am tired of trying. Instead, shrimply lean on Angelica when it's present.

Your models sans Angelica look wack, but I don't care that much. If FalseTweaks/Beddium/what have you has an API for enabling their AO, I'd be more than happy to integrate that too.

Behold, AOd modeled blocks (the fake stairs and funny green one):
<img width="854" height="480" alt="2026-08-05_02 12 26" src="https://github.com/user-attachments/assets/767e444f-b1d4-47c7-8a76-c01c2891546d" />

Requires https://github.com/GTNewHorizons/Angelica/pull/1989

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
