### PR TITLE
Bump GTNHExtLib dependency to include jvmdg 2.0.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,7 +16,7 @@ dependencies {
     compileOnlyApi("xyz.wagyourtail.jvmdowngrader:jvmdowngrader-java-api:${jvmDgVersion}:downgraded-8") { transitive = false } // LGPL 2.1
 
     // Slow-moving fat lib holding external deps
-    api("com.github.GTNewHorizons:GTNHExtLib:1.0.3") { transitive = false }
+    api("com.github.GTNewHorizons:GTNHExtLib:1.0.4") { transitive = false }
 
     // Tests run outside the DepLoader bootstrap; compileOnly does not reach test runtime.
     testRuntimeOnly("xyz.wagyourtail.jvmdowngrader:jvmdowngrader-java-api:${jvmDgVersion}:downgraded-8") { transitive = false }


### PR DESCRIPTION
## Summary
Bumps GTNHExtLib to include jvmdg 2.0.1, to match with https://github.com/GTNewHorizons/GTNHGradle/pull/84.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
