### PR TITLE
Compat w/ Alfheim - stop preinit mixins from messing with asjcore

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/PreInitMixinPlugin.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/PreInitMixinPlugin.java
@@ -4,15 +4,29 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.lib.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 
 public class PreInitMixinPlugin implements IMixinConfigPlugin {
 
+    private static final Logger LOGGER = LogManager.getLogger("GTNHLib|PreInit");
+
     @Override
     public void onLoad(String mixinPackage) {
-
+        // Mixingasm keeps untrusted coremod transformers out of Mixin's metadata passes, but ships as a DEFAULT-env
+        // Force it to run here. Stops pre-init mixins from causing trouble with Asjcore
+        try {
+            Class.forName("makamys.mixingasm.Mixingasm").getMethod("run").invoke(null);
+        } catch (ClassNotFoundException absent) {
+            LOGGER.warn(
+                    "Mixingasm not present; PREINIT mixin metadata passes will run untrusted coremod transformers, "
+                            + "which can break mods that patch classes only once");
+        } catch (ReflectiveOperationException e) {
+            LOGGER.warn("Could not run Mixingasm early; PREINIT metadata passes stay unprotected", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
Compat w/ Alfheim - stop preinit mixins from messing with asjcore

Fixes: https://github.com/GTNewHorizons/GTNHLib/issues/431

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
