### PR TITLE
Vanilla Color Code Rules Option + Minor JSON Crash Fix 

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/loading/ResourceLoc.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/loading/ResourceLoc.java
@@ -15,6 +15,7 @@ import net.minecraft.util.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 import com.gtnewhorizon.gtnhlib.client.model.state.StateModelMap;
 import com.gtnewhorizon.gtnhlib.client.model.unbaked.JSONModel;
 
@@ -26,8 +27,8 @@ public interface ResourceLoc<T> {
         try {
             final InputStream is = Minecraft.getMinecraft().getResourceManager().getResource(jsonPath).getInputStream();
             return gson.fromJson(new InputStreamReader(is), clazz());
-        } catch (JsonException e) {
-            MODEL_LOGGER.error("Failed to parse {}:{}", owner(), jsonPath.getResourcePath());
+        } catch (JsonException | JsonParseException e) {
+            MODEL_LOGGER.error("Failed to parse {}:{}", owner(), jsonPath.getResourcePath(), e);
         } catch (IOException e) {
             MODEL_LOGGER.error("Could not load {}:{}", owner(), jsonPath.getResourcePath());
         }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/state/MonopartState.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/state/MonopartState.java
@@ -51,7 +51,8 @@ public class MonopartState implements StateModelMap {
         public StateMatch(String s) {
             variantName = s;
 
-            if (s.isEmpty()) {
+            // "normal" is the vanilla key for a block with no properties
+            if (s.isEmpty() || "normal".equals(s)) {
                 matchAll = true;
                 states = null;
                 return;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/state/MonopartState.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/state/MonopartState.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.google.gson.JsonParseException;
 import com.gtnewhorizon.gtnhlib.blockstate.core.BlockState;
 import com.gtnewhorizon.gtnhlib.client.model.JSONVariant;
 import com.gtnewhorizon.gtnhlib.client.model.Weighted;
@@ -64,7 +65,7 @@ public class MonopartState implements StateModelMap {
             for (String c : s.split(",")) {
                 final int eqIndex = c.indexOf("=");
 
-                if (eqIndex == -1) throw new RuntimeException(
+                if (eqIndex == -1) throw new JsonParseException(
                         "Model variant predicate is missing an equals; expected it to be of the format 'property name=property value': '"
                                 + c
                                 + "'!");

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/font/FontRendering.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/font/FontRendering.java
@@ -35,10 +35,25 @@ public class FontRendering {
         default boolean handlesAmpCodes() {
             return false;
         }
+
+        /**
+         * Whether a {@code §x} hex color clears bold and the other style flags. Vanilla color codes always do; hex is
+         * the renderer's choice, and the default keeps them so widths match a renderer that carries styles through.
+         * Evaluated per call, so implementations may return a live value tied to configuration state.
+         */
+        default boolean hexColorResetsStyles() {
+            return false;
+        }
     }
 
     private static boolean preprocessorHandlesAmpCodes() {
         return textPreprocessor instanceof TextPreprocessor && ((TextPreprocessor) textPreprocessor).handlesAmpCodes();
+    }
+
+    /** Whether a {@code §x} hex color clears style flags, as the registered preprocessor's renderer draws it. */
+    public static boolean hexColorResetsStyles() {
+        return textPreprocessor instanceof TextPreprocessor
+            && ((TextPreprocessor) textPreprocessor).hexColorResetsStyles();
     }
 
     /**
@@ -150,6 +165,7 @@ public class FontRendering {
         float width = 0;
         boolean curBold = false;
         boolean spacingOmittedOnce = false;
+        final boolean hexResetsStyles = hexColorResetsStyles();
 
         for (int i = 0; i < str.length(); ++i) {
             char ch = str.charAt(i);
@@ -160,7 +176,8 @@ public class FontRendering {
                 char fmtChar = str.charAt(i);
                 if (Character.toLowerCase(fmtChar) == 'x' && preprocessorHandlesAmpCodes()
                         && isSectionXPayload(str, i + 1)) {
-                    // §x hex color: skip the payload, keep bold (renderer keeps styles through hex, unlike §0-f)
+                    // §x hex color: skip the payload; styles follow the renderer's rule.
+                    if (hexResetsStyles) curBold = false;
                     i += SECTION_X_PAYLOAD;
                 } else {
                     curBold = determineIfBold(curBold, fmtChar);
@@ -198,6 +215,7 @@ public class FontRendering {
         int lastBreakSpot = -1;
         boolean curBold = false;
         boolean spacingOmittedOnce = false;
+        final boolean hexResetsStyles = hexColorResetsStyles();
 
         IFontParameters fontParams = (IFontParameters) fr;
 
@@ -216,7 +234,8 @@ public class FontRendering {
                         char fmtChar = str.charAt(i);
                         if (Character.toLowerCase(fmtChar) == 'x' && preprocessorHandlesAmpCodes()
                                 && isSectionXPayload(str, i + 1)) {
-                            // §x hex color: skip payload, keep bold
+                            // §x hex color: skip payload; styles follow the renderer's rule.
+                            if (hexResetsStyles) curBold = false;
                             i += SECTION_X_PAYLOAD;
                         } else {
                             curBold = determineIfBold(curBold, fmtChar);
@@ -287,6 +306,7 @@ public class FontRendering {
         boolean curBold = false;
         boolean spacingOmittedOnce = false;
         boolean parsingFormatCode = false;
+        final boolean hexResetsStyles = hexColorResetsStyles();
 
         IFontParameters fontParams = (IFontParameters) fr;
 
@@ -300,7 +320,8 @@ public class FontRendering {
                     && Character.toLowerCase(str.charAt(i + 1)) == 'x'
                     && preprocessorHandlesAmpCodes()
                     && isSectionXPayload(str, i + 2)) {
-                // §x hex color: copy the whole token, no width, keep bold
+                // §x hex color: copy the whole token, no width; styles follow the renderer's rule.
+                if (hexResetsStyles) curBold = false;
                 for (int k = 0; k < SECTION_X_LENGTH && i + k < str.length(); k++) {
                     stringbuilder.append(str.charAt(i + k));
                 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/util/font/FontRendering.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/util/font/FontRendering.java
@@ -53,7 +53,7 @@ public class FontRendering {
     /** Whether a {@code §x} hex color clears style flags, as the registered preprocessor's renderer draws it. */
     public static boolean hexColorResetsStyles() {
         return textPreprocessor instanceof TextPreprocessor
-            && ((TextPreprocessor) textPreprocessor).hexColorResetsStyles();
+                && ((TextPreprocessor) textPreprocessor).hexColorResetsStyles();
     }
 
     /**


### PR DESCRIPTION
## Summary

In order for the Hex Text Compatibility PR to merge for Angelica: https://github.com/GTNewHorizons/Angelica/pull/1972 

This system needs to be in place for GTNHLib so that Angelica can follow formatting rules of Hex Text as an optional config to put create a parity with Vanilla MC Behavior in which Hex Colors reset Formatting codes like Bold. If this isn't in, then string lengths are off for GTNHLib and Hex Text when joined together. This change is simply adding an API Extension for a minor point for Hex Text to modify / resolve

As for the JSON Issue. I found that some legacy JSON formats produced a crash with GTNHLib in Resource packs when loading up, this simple change just allows it support "normal" blocks formatting which some ResourcePacks carry.

## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)