### PR TITLE
Improve edge cases of `@EventBusSubscriber`

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/core/fml/transformers/EventBusSubTransformer.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/core/fml/transformers/EventBusSubTransformer.java
@@ -43,7 +43,7 @@ public class EventBusSubTransformer implements IClassTransformer {
     private static final List<String> ANNOTATIONS = Arrays
             .asList(OPTIONAL_DESC, SIDEONLY_DESC, SUBSCRIBE_DESC, CONDITION_DESC);
     private static final String CURRENT_SIDE = FMLLaunchHandler.side().name();
-    private static final ObjectSet<String> classesToVisit = EventBusUtil.getClassesToVisit();
+    private static final ObjectSet<String> classesToVisit = EventBusUtil.classesToVisit;
 
     @Override
     public byte[] transform(String name, String transformedName, byte[] basicClass) {
@@ -75,7 +75,7 @@ public class EventBusSubTransformer implements IClassTransformer {
             boolean condition = usableAnnotations.containsKey(CONDITION_DESC);
             if ((mn.access & Opcodes.ACC_STATIC) == 0) {
                 if (!condition && subscribe != null) {
-                    EventBusUtil.getInvalidMethods()
+                    EventBusUtil.invalidMethods
                             .add("Encountered unexpected non-static method: " + getMethodKey(transformedName, mn));
                 }
                 continue;
@@ -83,17 +83,17 @@ public class EventBusSubTransformer implements IClassTransformer {
 
             if (condition) {
                 if (mn.desc.equals("()Z")) {
-                    EventBusUtil.getConditionsToCheck().put(transformedName, mn.name + mn.desc);
+                    EventBusUtil.conditionsToCheck.put(transformedName, mn.name + mn.desc);
                     changed |= changeAccess(transformedName, mn);
                 } else {
-                    EventBusUtil.getInvalidMethods().add(
+                    EventBusUtil.invalidMethods.add(
                             "Invalid condition method: " + getMethodKey(transformedName, mn)
                                     + ". Condition method must have no parameters and return a boolean.");
                 }
                 continue;
             } else {
                 if (!isValidDesc(mn.desc)) {
-                    EventBusUtil.getInvalidMethods().add(
+                    EventBusUtil.invalidMethods.add(
                             "Invalid event handler method: " + getMethodKey(transformedName, mn)
                                     + ". Event handler method must have exactly one Event parameter and return void.");
                     continue;
@@ -131,7 +131,7 @@ public class EventBusSubTransformer implements IClassTransformer {
                 }
             }
 
-            EventBusUtil.getMethodsToSubscribe().computeIfAbsent(transformedName, k -> new ObjectOpenHashSet<>())
+            EventBusUtil.methodsToSubscribe.computeIfAbsent(transformedName, k -> new ObjectOpenHashSet<>())
                     .add(methodInfo);
             if (DEBUG_EVENT_BUS) {
                 LOGGER.info("Found subscribed method {}", methodInfo.getKey());

--- a/src/main/java/com/gtnewhorizon/gtnhlib/core/fml/transformers/EventBusSubTransformer.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/core/fml/transformers/EventBusSubTransformer.java
@@ -91,6 +91,13 @@ public class EventBusSubTransformer implements IClassTransformer {
                                     + ". Condition method must have no parameters and return a boolean.");
                 }
                 continue;
+            } else {
+                if (!isValidDesc(mn.desc)) {
+                    EventBusUtil.getInvalidMethods().add(
+                            "Invalid event handler method: " + getMethodKey(transformedName, mn)
+                                    + ". Event handler method must have exactly one Event parameter and return void.");
+                    continue;
+                }
             }
 
             if (subscribe == null) {
@@ -200,5 +207,18 @@ public class EventBusSubTransformer implements IClassTransformer {
 
     private static String getMethodKey(String className, MethodNode mn) {
         return className + " " + mn.name + mn.desc;
+    }
+
+    /**
+     * Check whether this method descriptor is a possible descriptor for an event handler method. Specifically, it
+     * checks that the method takes one non-literal parameter and returns void. Does not check whether that parameter is
+     * a valid Event method, since that would require class-loading
+     *
+     * @param desc The descriptor of the static method.
+     * @return True if the method could potentially be an event handler method, false if the method is guaranteed to be
+     *         an invalid event handler method.
+     */
+    private static boolean isValidDesc(String desc) {
+        return desc.startsWith("(L") && desc.endsWith(";)V") && desc.lastIndexOf(';', desc.length() - 4) == -1;
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/AutoEventBus.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/AutoEventBus.java
@@ -109,11 +109,10 @@ public class AutoEventBus {
             if (invalidMethods.size() == 1) {
                 throw new IllegalArgumentException(invalidMethods.get(0));
             } else if (invalidMethods.size() > 1) {
-                int i;
-                for (i = 0; i < invalidMethods.size() - 1; i++) {
-                    LOGGER.error(invalidMethods.get(i));
-                }
-                throw new IllegalArgumentException("Encountered" + i + "invalid methods. " + invalidMethods.get(i));
+                throw new IllegalArgumentException(
+                        "Encountered " + invalidMethods.size()
+                                + " invalid methods.\n - "
+                                + String.join("\n - ", invalidMethods));
             }
         }
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/AutoEventBus.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/AutoEventBus.java
@@ -45,11 +45,13 @@ import lombok.NoArgsConstructor;
 public class AutoEventBus {
 
     private static final Logger LOGGER = LogManager.getLogger("GTNHLib EventBus");
-    private static final DummyEvent INVALID_EVENT = new DummyEvent();
     private static final Object2ObjectMap<String, Event> eventCache = new Object2ObjectOpenHashMap<>();
     private static final Object2BooleanMap<String> optionalMods = new Object2BooleanOpenHashMap<>();
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
     private static final MethodType CONDITION_TYPE = MethodType.methodType(boolean.class);
+
+    private static final DummyEvent INVALID_EVENT = new DummyEvent();
+    private static final DummyEvent NOT_AN_EVENT = new DummyEvent();
 
     private enum EventBusType {
 
@@ -127,7 +129,17 @@ public class AutoEventBus {
                 }
 
                 Event event = getCachedEvent(EventBusUtil.getParameterClassName(method.desc));
-                if (INVALID_EVENT.equals(event)) continue;
+                if (event == INVALID_EVENT) {
+                    continue;
+                } else if (event == NOT_AN_EVENT) {
+                    EventBusUtil.getInvalidMethods().add(
+                            "Invalid event handler method: " + method.declaringClass
+                                    + " "
+                                    + method.name
+                                    + method.desc
+                                    + ". The parameter of an event handler method must extend cpw.mods.fml.common.eventhandler.Event");
+                    continue;
+                }
 
                 StaticASMEventHandler listener = new StaticASMEventHandler(method);
                 for (EventBusType bus : EventBusType.VALUES) {
@@ -152,6 +164,9 @@ public class AutoEventBus {
         return eventCache.computeIfAbsent(eventClass, e -> {
             try {
                 Class<?> clazz = Class.forName(eventClass, false, Loader.instance().getModClassLoader());
+
+                if (!Event.class.isAssignableFrom(clazz)) return NOT_AN_EVENT;
+
                 return (Event) ConstructorUtils.invokeConstructor(clazz);
             } catch (NoClassDefFoundError | ExceptionInInitializerError | Exception ex) {
                 // Event was likely for a mod that is not loaded or an invalid side.

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/AutoEventBus.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/AutoEventBus.java
@@ -38,10 +38,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectList;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AutoEventBus {
 
     private static final Logger LOGGER = LogManager.getLogger("GTNHLib EventBus");
@@ -52,6 +49,8 @@ public class AutoEventBus {
 
     private static final DummyEvent INVALID_EVENT = new DummyEvent();
     private static final DummyEvent NOT_AN_EVENT = new DummyEvent();
+
+    private AutoEventBus() {}
 
     private enum EventBusType {
 
@@ -89,7 +88,7 @@ public class AutoEventBus {
             for (String className : entry.getValue()) {
                 try {
                     Class<?> clazz = Class.forName(className, false, Loader.instance().getModClassLoader());
-                    String conditionToCheck = EventBusUtil.getConditionsToCheck().get(className);
+                    String conditionToCheck = EventBusUtil.conditionsToCheck.get(className);
                     if (conditionToCheck != null && !isConditionMet(clazz, conditionToCheck)) {
                         if (DEBUG_EVENT_BUS) {
                             LOGGER.info("Skipping registration for {}, condition not met", className);
@@ -97,7 +96,7 @@ public class AutoEventBus {
                         continue;
                     }
 
-                    ObjectSet<MethodInfo> methods = EventBusUtil.getMethodsToSubscribe().get(className);
+                    ObjectSet<MethodInfo> methods = EventBusUtil.methodsToSubscribe.get(className);
                     if (methods == null || methods.isEmpty()) continue;
                     register(entry.getKey(), clazz, methods);
                 } catch (ClassNotFoundException e) {
@@ -107,7 +106,7 @@ public class AutoEventBus {
         }
 
         if (phase == Phase.INIT) {
-            ObjectList<String> invalidMethods = EventBusUtil.getInvalidMethods();
+            ObjectList<String> invalidMethods = EventBusUtil.invalidMethods;
             if (invalidMethods.size() == 1) {
                 throw new IllegalArgumentException(invalidMethods.get(0));
             } else if (invalidMethods.size() > 1) {
@@ -132,7 +131,7 @@ public class AutoEventBus {
                 if (event == INVALID_EVENT) {
                     continue;
                 } else if (event == NOT_AN_EVENT) {
-                    EventBusUtil.getInvalidMethods().add(
+                    EventBusUtil.invalidMethods.add(
                             "Invalid event handler method: " + method.declaringClass
                                     + " "
                                     + method.name

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/AutoEventBus.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/AutoEventBus.java
@@ -90,7 +90,7 @@ public class AutoEventBus {
                     String conditionToCheck = EventBusUtil.getConditionsToCheck().get(className);
                     if (conditionToCheck != null && !isConditionMet(clazz, conditionToCheck)) {
                         if (DEBUG_EVENT_BUS) {
-                            LOGGER.info("Skipping registration for {}, condition not met", clazz.getSimpleName());
+                            LOGGER.info("Skipping registration for {}, condition not met", className);
                         }
                         continue;
                     }
@@ -168,6 +168,10 @@ public class AutoEventBus {
         try {
             MethodHandle handle = MethodHandles.publicLookup()
                     .findStatic(clazz, condition.substring(0, condition.indexOf("(")), CONDITION_TYPE);
+
+            // Note: `LambdaMetafactory` allows us to run the method without loading the full class, so if any of the
+            // event handlers use event classes that are not present on the class path, we don't crash the game by
+            // loading them before testing the `@EventBusSubscriber.Condition`.
             CallSite call = LambdaMetafactory.metafactory(
                     LOOKUP,
                     "getAsBoolean",

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusUtil.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusUtil.java
@@ -21,7 +21,7 @@ import lombok.Getter;
 
 public final class EventBusUtil {
 
-    public static final Boolean DEBUG_EVENT_BUS = Boolean.getBoolean("gtnhlib.debug.eventbus");
+    public static final boolean DEBUG_EVENT_BUS = Boolean.getBoolean("gtnhlib.debug.eventbus");
     private static final String CURRENT_SIDE = FMLLaunchHandler.side().name();
 
     @Getter

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusUtil.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/EventBusUtil.java
@@ -17,21 +17,16 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectList;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
-import lombok.Getter;
 
 public final class EventBusUtil {
 
     public static final boolean DEBUG_EVENT_BUS = Boolean.getBoolean("gtnhlib.debug.eventbus");
     private static final String CURRENT_SIDE = FMLLaunchHandler.side().name();
 
-    @Getter
-    private static final ObjectSet<String> classesToVisit = new ObjectOpenHashSet<>();
-    @Getter
-    private static final Object2ObjectMap<String, ObjectSet<MethodInfo>> methodsToSubscribe = new Object2ObjectOpenHashMap<>();
-    @Getter
-    private static final Object2ObjectMap<String, String> conditionsToCheck = new Object2ObjectOpenHashMap<>();
-    @Getter
-    private static final ObjectList<String> invalidMethods = new ObjectArrayList<>();
+    public static final ObjectSet<String> classesToVisit = new ObjectOpenHashSet<>();
+    public static final Object2ObjectMap<String, ObjectSet<MethodInfo>> methodsToSubscribe = new Object2ObjectOpenHashMap<>();
+    public static final Object2ObjectMap<String, String> conditionsToCheck = new Object2ObjectOpenHashMap<>();
+    public static final ObjectList<String> invalidMethods = new ObjectArrayList<>();
 
     static String getParameterClassInternal(String desc) {
         return desc.substring(desc.indexOf("(") + 2, desc.indexOf(";"));
@@ -47,7 +42,7 @@ public final class EventBusUtil {
 
     public static void harvestData(ASMDataTable table) {
         Set<ASMDataTable.ASMData> asmData = table.getAll(EventBusSubscriber.class.getName());
-        ObjectSet<String> excludedClasses = getExcludedClasses(table);;
+        ObjectSet<String> excludedClasses = getExcludedClasses(table);
         for (ASMDataTable.ASMData data : asmData) {
             Map<String, Object> info = data.getAnnotationInfo();
             String className = data.getClassName();
@@ -99,4 +94,5 @@ public final class EventBusUtil {
 
         return !StringUtils.containsIgnoreCase(className, "client") && !side.equals("CLIENT");
     }
+
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/StaticASMEventHandler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventbus/StaticASMEventHandler.java
@@ -1,6 +1,13 @@
 package com.gtnewhorizon.gtnhlib.eventbus;
 
-import static org.objectweb.asm.Opcodes.*;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.CHECKCAST;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V1_6;
 
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
@@ -9,7 +16,6 @@ import org.objectweb.asm.Type;
 import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.IEventListener;
-import lombok.Getter;
 
 public class StaticASMEventHandler implements IEventListener {
 
@@ -22,7 +28,6 @@ public class StaticASMEventHandler implements IEventListener {
     private final IEventListener handler;
     private final String readable;
     private final boolean receiveCanceled;
-    @Getter
     private final EventPriority priority;
 
     StaticASMEventHandler(MethodInfo method) throws Exception {
@@ -86,6 +91,10 @@ public class StaticASMEventHandler implements IEventListener {
                 EventBusUtil.getSimpleClassName(declaring),
                 method.getName(),
                 EventBusUtil.getSimpleClassName(param));
+    }
+
+    public EventPriority getPriority() {
+        return this.priority;
     }
 
     private static class ASMClassLoader extends ClassLoader {


### PR DESCRIPTION
## Summary
Fixes several issues with `@EventBusSubscriber`.

- Prevents a crash caused by unintentional class loading when `gtnhlib.debug.eventbus` is set to true.
- Improves the error message created when multiple methods within an `@EventBusSubsciber` are invalid. Previously, it would scatter the error across hundreds of lines, and it would log the wrong number of total invalid methods.
- Adds extra error messages for when an event handler method has the wrong signature, loudly preventing users from trying to handle FML lifecycle events (which can only be handled from a mod container) and preventing weird bytecode validation errors when a method has the wrong signature.

Does not fix multiple `@EventBusSubscriber.Condition` methods having one method picked arbitrarily with no warning (yet).

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
