### PR TITLE
Only block old blockstates

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/models/MixinFileResourcePack.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/models/MixinFileResourcePack.java
@@ -114,9 +114,9 @@ public abstract class MixinFileResourcePack extends AbstractResourcePack impleme
         var pathParts = resource.split("/");
         if (pathParts.length < 4) return false; // too short to be a blockstate or model
         if (!"assets".equals(pathParts[0])) return false;
-        if (!"blockstates".equals(pathParts[2]) && !"models".equals(pathParts[2])) return false;
+        if (!"blockstates".equals(pathParts[2])) return false;
 
-        // This is a blockstate or model, reject it if it's too old.
+        // This is a blockstate, reject it if it's too old.
         return packFormat < PACK_FORMAT_MC_13_X;
     }
 }


### PR DESCRIPTION
Apparently, ProjectBlue uses JSON for it's model format. To avoid breaking other mods which happen to use JSON for their model format, we only drop blockstates from old packs.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
