### PR TITLE
Fix resource packs not loading at startup

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/models/MixinFileResourcePack.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/models/MixinFileResourcePack.java
@@ -4,24 +4,26 @@ import static com.gtnewhorizon.gtnhlib.core.GTNHLibCore.MODEL_LOGGER;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.AbstractResourcePack;
 import net.minecraft.client.resources.FileResourcePack;
-import net.minecraft.client.resources.data.IMetadataSection;
-import net.minecraft.client.resources.data.PackMetadataSection;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.gtnewhorizon.gtnhlib.client.model.loading.ModelResourcePack;
 import com.gtnewhorizon.gtnhlib.client.model.loading.RPInfo;
 import com.gtnewhorizon.gtnhlib.client.model.unbaked.JSONModel;
@@ -86,6 +88,9 @@ public abstract class MixinFileResourcePack extends AbstractResourcePack impleme
     @Unique
     private static final String METADATA_FILE = "pack.mcmeta";
 
+    @Unique
+    private int nhlib$packFormat = -1;
+
     /// Block old resourcepacks from loading blockstates or models.
     /// @return True if the resource SHOULDN'T load, false if it SHOULD.
     @Definition(id = "zipentry", local = @Local(type = ZipEntry.class))
@@ -95,28 +100,38 @@ public abstract class MixinFileResourcePack extends AbstractResourcePack impleme
         // Return the default for the metadata, or getting it below will infinitely recurse.
         if (original || METADATA_FILE.equals(resource)) return original;
 
-        if (!resource.endsWith(".json")) return false; // not a JSON blockstate
-        var pathParts = resource.split("/");
-        if (pathParts.length < 4) return false; // too short to be a blockstate
-        if (!"assets".equals(pathParts[0])) return false;
-        if (!"blockstates".equals(pathParts[2])) return false;
+        // Not a JSON model or blockstate
+        if (!resource.endsWith(".json") || !resource.startsWith("assets/")) return false;
+
+        int firstSlash = 6; // Index of slash after "assets"
+        int secondSlash = resource.indexOf('/', firstSlash + 1);
+        if (secondSlash == -1 || !resource.startsWith("blockstates/", secondSlash + 1)) return false;
 
         // This song and dance is needed because some calls to getInputStreamByName expect it to never fail,
         // since they're referring to resources bundled in jars. So while the original has a checked exception, we can't
         // rely on everyone checking it.
-        final int packFormat;
-        IMetadataSection packFormatSection = null;
-        try {
-            packFormatSection = getPackMetadata(
-                    Minecraft.getMinecraft().getResourcePackRepository().rprMetadataSerializer,
-                    "pack");
-        } catch (IOException e) {
-            // If the above fails, pack metadata is null and thus format is assumed to be 1 (i.e. old).
-        }
-        if (!(packFormatSection instanceof PackMetadataSection metadata)) packFormat = 1;
-        else packFormat = metadata.getPackFormat();
+        if (this.nhlib$packFormat == -1) {
+            try (InputStream is = getInputStreamByName(METADATA_FILE)) {
+                if (is != null) {
+                    JsonObject json = new JsonParser().parse(new InputStreamReader(is, StandardCharsets.UTF_8))
+                            .getAsJsonObject();
+                    if (json.has("pack")) {
+                        JsonObject packObj = json.getAsJsonObject("pack");
+                        if (packObj.has("pack_format")) {
+                            this.nhlib$packFormat = packObj.get("pack_format").getAsInt();
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                // If the above fails, pack metadata is null and thus format is assumed to be 1 (i.e. old).
+            }
 
-        // This is a blockstate, reject it if it's too old.
-        return packFormat < PACK_FORMAT_MC_13_X;
+            if (this.nhlib$packFormat == -1) {
+                this.nhlib$packFormat = 1;
+            }
+        }
+
+        // Reject it if it's too old.
+        return this.nhlib$packFormat < PACK_FORMAT_MC_13_X;
     }
 }


### PR DESCRIPTION
## Summary
Fixes #450
(Related: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26364)

In 0.11.38 a bug was introduced in nhlib$blockOldModels. The intention was to prevent legacy resource packs from loading blockstates/models however it introduced a regression where enabled resource packs weren't applied when launching the game.

Originally what would happen is that in the ResourcePackRepository constructor it would scan the resource packs folder and call getPackImage() for pack.png. nhlib$blockOldModels would intercept "pack.png" and call rprMetadataSerializer. Because of ResourcePackRepository still running the other callback would return null which would throw a unhandled NullPointerException. Minecraft would then catch the exception and drop the pack. This leads to every pack being cleared since all enabled packs would not be found in the repository. This is also why after the game loads you can reapply them without issue.

In this PR I fixed this by parsing pack.mcmeta with GSON instead of ResourcePackRepository. If I'm not mistaken, pack.mcmeta must always be valid JSON. This allows for reading the json in a slef contained way that doesn't have any lifecycle issues.

Additionally, I reordered checks for checking blockstate resources so that non-jsoin files and non-blockstate paths would return without querying metadata. I also cached pack_format per resource pack instead of rechecking pack.mcmeta every blockstate lookup.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
