### PR TITLE
Small optimization to renderWorldBlock and fix getBiomeGenForCoords

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/ModelISBRH.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/ModelISBRH.java
@@ -81,7 +81,8 @@ public class ModelISBRH implements ISimpleBlockRenderingHandler, IItemRenderer {
             RenderBlocks renderer) {
         // Setup for rendering
         final Tessellator tesselator = TessellatorManager.get();
-        final var wrappedContext = new WorldWrapper(world, block, x, y, z);
+        final IBlockAccess wrappedContext = (world.getBlock(x, y, z) == block) ? world
+                : new WorldWrapper(world, block, x, y, z);
         worldContext.set(wrappedContext, x, y, z, RAND);
         final int meta = wrappedContext.getBlockMetadata(x, y, z);
 
@@ -603,7 +604,7 @@ public class ModelISBRH implements ISimpleBlockRenderingHandler, IItemRenderer {
 
         @Override
         public BiomeGenBase getBiomeGenForCoords(int x, int z) {
-            return wrapped.getBiomeGenForCoords(x, y);
+            return wrapped.getBiomeGenForCoords(x, z);
         }
 
         @Override


### PR DESCRIPTION
## Summary
In ModelISBRH I noticed 2 issues:
1. In getBiomeGenForCoords on WorldWrapper the mirror's call was (x, y) instead of (x, z).
2. In renderWorldBlock it always made a new WorldWrapper, I changed this to only instantiate WorldWrapper when a block is being replaced. In my testing this improved chunk meshing performance. I tested this change on the lecturn test block.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
