### PR TITLE
Add ChatComponentItemDisplayName

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/CommonProxy.java
@@ -18,6 +18,7 @@ import com.gtnewhorizon.gtnhlib.chat.ChatComponentCustomRegistry;
 import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentEnergy;
 import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentFluid;
 import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentFluidName;
+import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentItemDisplayName;
 import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentItemName;
 import com.gtnewhorizon.gtnhlib.chat.customcomponents.ChatComponentNumber;
 import com.gtnewhorizon.gtnhlib.commands.TitleCommand;
@@ -88,6 +89,7 @@ public class CommonProxy {
         ChatComponentCustomRegistry.register(ChatComponentEnergy::new);
         ChatComponentCustomRegistry.register(ChatComponentFluidName::new);
         ChatComponentCustomRegistry.register(ChatComponentItemName::new);
+        ChatComponentCustomRegistry.register(ChatComponentItemDisplayName::new);
 
         // Number formatting config registration. Primarily aimed at client side, but does exist on server side
         // as well, just in-case calls are made to number formatting.

--- a/src/main/java/com/gtnewhorizon/gtnhlib/chat/customcomponents/ChatComponentItemDisplayName.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/chat/customcomponents/ChatComponentItemDisplayName.java
@@ -1,0 +1,67 @@
+package com.gtnewhorizon.gtnhlib.chat.customcomponents;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
+
+import com.gtnewhorizon.gtnhlib.chat.AbstractChatComponentCustom;
+
+import cpw.mods.fml.common.network.ByteBufUtils;
+
+/**
+ * Resolves an item's display name on the client, without the brackets {@link ChatComponentItemName} adds. Useful
+ * outside of chat, e.g. in a GUI label built on a dedicated server, where client language files are not loaded.
+ */
+public class ChatComponentItemDisplayName extends AbstractChatComponentBuffer<ChatComponentItemDisplayName> {
+
+    public ItemStack stack = null;
+    /**
+     * If true and the display name ends with a closing parenthesis, only the contents of the last pair of parentheses
+     * are kept, e.g. "Extruder Shape (Rod)" becomes "Rod". Otherwise the whole name is used.
+     */
+    public boolean lastParenthesesOnly = false;
+
+    public ChatComponentItemDisplayName() {}
+
+    public ChatComponentItemDisplayName(ItemStack stack) {
+        this(stack, false);
+    }
+
+    public ChatComponentItemDisplayName(ItemStack stack, boolean lastParenthesesOnly) {
+        this.stack = stack;
+        this.lastParenthesesOnly = lastParenthesesOnly;
+    }
+
+    @Override
+    public String getID() {
+        return "gtnhlib:ChatComponentItemDisplayName";
+    }
+
+    @Override
+    protected AbstractChatComponentCustom copySelf() {
+        return new ChatComponentItemDisplayName(stack == null ? null : stack.copy(), lastParenthesesOnly);
+    }
+
+    @Override
+    public String getUnformattedTextForChat() {
+        if (stack == null) return "";
+        final String name = stack.getDisplayName();
+        if (name == null || name.isEmpty()) return "";
+        if (lastParenthesesOnly && name.endsWith(")")) {
+            final int open = name.lastIndexOf('(');
+            if (open >= 0) return name.substring(open + 1, name.length() - 1);
+        }
+        return name;
+    }
+
+    @Override
+    public void encode(PacketBuffer buf) {
+        ByteBufUtils.writeItemStack(buf, this.stack);
+        buf.writeBoolean(this.lastParenthesesOnly);
+    }
+
+    @Override
+    public void decode(PacketBuffer buf) {
+        this.stack = ByteBufUtils.readItemStack(buf);
+        this.lastParenthesesOnly = buf.readBoolean();
+    }
+}


### PR DESCRIPTION
## Summary

ChatComponentItemName wraps the name in square brackets, following vanilla func_151000_E, which is what chat wants but not what a GUI label wants. Outside of chat the brackets have to be stripped back off, and there is no way to ask for the bare name.

This adds a component that resolves the display name without brackets, plus a flag to keep only the contents of the last pair of parentheses ("Extruder Shape (Rod)" becomes "Rod"), which is a common shape for 1.7.10 item names when only the variant part is wanted.

Needed by GTNewHorizons/Applied-Energistics-2-Unofficial#1545, where an interface name suffix is built on a dedicated server and has to be localized on the client.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
