### PR TITLE
Fixes optifine compatibility

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/TessellatorManager.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/renderer/TessellatorManager.java
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.Tessellator;
 
 import org.apache.logging.log4j.LogManager;
@@ -282,12 +283,14 @@ public class TessellatorManager {
     // --------------- DIRECT TESSELLATOR ---------------
 
     public static final int DEFAULT_BUFFER_SIZE = 0x8000; // 32KB, enough to store 1024 full-sized vertices
-    private static final int BUFFER_CAPACITY = Tessellator.byteBuffer.capacity();
+    private static final int BUFFER_CAPACITY = 0x200000 * 4;
     public static final int DIRECT_TESSELLATOR_STACK_DEPTH = 16;
 
+    private static final ByteBuffer byteBuffer = GLAllocation.createDirectByteBuffer(0x200000 * 4);
+
     // Instances to use for capturing to vbo's (Cannot be used outside the tessellator stack)
-    private static final DirectTessellator mainInstance = new DirectTessellator(Tessellator.byteBuffer);
-    private static final CallbackTessellator mainCallbackInstance = new CallbackTessellator(Tessellator.byteBuffer);
+    private static final DirectTessellator mainInstance = new DirectTessellator(byteBuffer);
+    private static final CallbackTessellator mainCallbackInstance = new CallbackTessellator(byteBuffer);
 
     // Any Tessellator that uses the Tessellator.byteBuffer is considered to be the "main instance"
     // This is to prevent new buffer allocations every capture
@@ -313,7 +316,7 @@ public class TessellatorManager {
             directTessellatorIndex--;
             throw new IllegalStateException("DirectTessellator stack overflow");
         }
-        mainInstanceInStack = mainInstanceInStack || tessellator.baseBuffer == Tessellator.byteBuffer;
+        mainInstanceInStack = mainInstanceInStack || tessellator.baseBuffer == byteBuffer;
         directTessellators[directTessellatorIndex] = tessellator;
     }
 
@@ -375,7 +378,7 @@ public class TessellatorManager {
         if (!hasDirectTessellator()) throw new IllegalStateException("Tried to stop capturing when not capturing!");
         final DirectTessellator tessellator = getDirectTessellator();
         directTessellators[directTessellatorIndex--] = null;
-        mainInstanceInStack = mainInstanceInStack && tessellator.baseBuffer != Tessellator.byteBuffer;
+        mainInstanceInStack = mainInstanceInStack && tessellator.baseBuffer != byteBuffer;
         tessellator.onRemovedFromStack();
     }
 


### PR DESCRIPTION
## Summary
Fixes a compatibility issue with OptiFine caused by static access to `Tessellator.byteBuffer`.

### Problem
In standard Forge environments, `Tessellator.byteBuffer` is a static field. However, OptiFine refactors `Tessellator` and transforms `byteBuffer` into an instance field. Direct static access to this field leads to a crash when OptiFine is installed.

### Solution
Replaced direct static access to `Tessellator.byteBuffer` by constructing a dedicated local `ByteBuffer`. This minimal, non-intrusive approach fixes the OptiFine crash without needing invasive runtime OptiFine detection or complex reflection.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge