### PR TITLE
Add inventoryCount to InventoryChangedEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Shared code library for GTNH mods.
 
 ### Events
 
-- Fires `InventoryChangedEvent` when a player's net item holdings change. Subscribe to `ItemAdded` or `ItemRemoved`, which carry the changed `ItemStack` and a signed delta.
+- Fires `InventoryChangedEvent` when a player's net item holdings change. Subscribe to `ItemAdded` or `ItemRemoved`, which carry the changed `ItemStack`, a signed delta, and `inventoryCount`, the player's total of that item after the change.
 - Items are matched by type and metadata ignoring NBT, so sorting an inventory fires nothing. Scans run every few ticks (configurable).
 - Fires `PickBlockEvent` when a player middle-clicks a block.
 - Mark a class `@EventBusSubscriber` to auto-register its `@SubscribeEvent` methods. Choose the side and load phase in the annotation. No manual registration needed.

--- a/src/main/java/com/gtnewhorizon/gtnhlib/event/InventoryChangedEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/event/InventoryChangedEvent.java
@@ -4,8 +4,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 
-import lombok.Getter;
-
 /**
  * Fired when a player's inventory changes (both client and server). Not cancelable. Subscribe to concrete
  * {@link ItemAdded} / {@link ItemRemoved} subclasses (1.7.10 Forge cannot register against abstract base without no-arg

--- a/src/main/java/com/gtnewhorizon/gtnhlib/event/InventoryChangedEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/event/InventoryChangedEvent.java
@@ -1,9 +1,10 @@
 package com.gtnewhorizon.gtnhlib.event;
 
-import lombok.Getter;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.player.PlayerEvent;
+
+import lombok.Getter;
 
 /**
  * Fired when a player's inventory changes (both client and server). Not cancelable. Subscribe to concrete

--- a/src/main/java/com/gtnewhorizon/gtnhlib/event/InventoryChangedEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/event/InventoryChangedEvent.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizon.gtnhlib.event;
 
+import lombok.Getter;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -14,9 +15,14 @@ public abstract class InventoryChangedEvent extends PlayerEvent {
     /** The changed item (representative; identity ignores NBT). Shared across listeners - copy before mutating. */
     public final ItemStack item;
 
-    protected InventoryChangedEvent(EntityPlayer player, ItemStack item) {
+    /** Total amount of {@link #item} the player holds after this change (NBT-insensitive, same identity rules). */
+    @Getter
+    private final int inventoryCount;
+
+    protected InventoryChangedEvent(EntityPlayer player, ItemStack item, int inventoryCount) {
         super(player);
         this.item = item;
+        this.inventoryCount = inventoryCount;
     }
 
     /** Absolute amount of the change (always positive). */
@@ -30,8 +36,8 @@ public abstract class InventoryChangedEvent extends PlayerEvent {
     /** Player gained {@link #item}. */
     public static class ItemAdded extends InventoryChangedEvent {
 
-        public ItemAdded(EntityPlayer player, ItemStack item) {
-            super(player, item);
+        public ItemAdded(EntityPlayer player, ItemStack item, int inventoryCount) {
+            super(player, item, inventoryCount);
         }
 
         @Override
@@ -43,8 +49,8 @@ public abstract class InventoryChangedEvent extends PlayerEvent {
     /** Player lost {@link #item}. */
     public static class ItemRemoved extends InventoryChangedEvent {
 
-        public ItemRemoved(EntityPlayer player, ItemStack item) {
-            super(player, item);
+        public ItemRemoved(EntityPlayer player, ItemStack item, int inventoryCount) {
+            super(player, item, inventoryCount);
         }
 
         @Override

--- a/src/main/java/com/gtnewhorizon/gtnhlib/event/InventoryChangedEvent.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/event/InventoryChangedEvent.java
@@ -17,8 +17,7 @@ public abstract class InventoryChangedEvent extends PlayerEvent {
     public final ItemStack item;
 
     /** Total amount of {@link #item} the player holds after this change (NBT-insensitive, same identity rules). */
-    @Getter
-    private final int inventoryCount;
+    public final int inventoryCount;
 
     protected InventoryChangedEvent(EntityPlayer player, ItemStack item, int inventoryCount) {
         super(player);

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventhandlers/InventoryEventDebugHandler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventhandlers/InventoryEventDebugHandler.java
@@ -32,7 +32,7 @@ public final class InventoryEventDebugHandler {
                 event.getDelta(),
                 event.item.getDisplayName(),
                 event.getCount(),
-                event.getInventoryCount(),
+                event.inventoryCount,
                 player.getCommandSenderName());
 
         if (player.worldObj.isRemote) {
@@ -44,7 +44,7 @@ public final class InventoryEventDebugHandler {
                                     + " x"
                                     + event.getCount()
                                     + " (total "
-                                    + event.getInventoryCount()
+                                    + event.inventoryCount
                                     + ")"));
         }
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/eventhandlers/InventoryEventDebugHandler.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/eventhandlers/InventoryEventDebugHandler.java
@@ -26,18 +26,26 @@ public final class InventoryEventDebugHandler {
         final String side = player.worldObj.isRemote ? "CLIENT" : "SERVER";
         final String verb = event.getDelta() > 0 ? "ADDED" : "REMOVED";
         GTNHLib.LOG.info(
-                "[InvEvent/{}] {} (delta {}) {} x{} for {}",
+                "[InvEvent/{}] {} (delta {}) {} x{} (total {}) for {}",
                 side,
                 verb,
                 event.getDelta(),
                 event.item.getDisplayName(),
                 event.getCount(),
+                event.getInventoryCount(),
                 player.getCommandSenderName());
 
         if (player.worldObj.isRemote) {
             player.addChatMessage(
                     new ChatComponentText(
-                            "[InvEvent] " + verb + " " + event.item.getDisplayName() + " x" + event.getCount()));
+                            "[InvEvent] " + verb
+                                    + " "
+                                    + event.item.getDisplayName()
+                                    + " x"
+                                    + event.getCount()
+                                    + " (total "
+                                    + event.getInventoryCount()
+                                    + ")"));
         }
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/inventory/InventoryEventListeners.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/inventory/InventoryEventListeners.java
@@ -29,8 +29,8 @@ public final class InventoryEventListeners {
         if (ready) return;
         forgeBusId = ((EventBusAccessor) (Object) MinecraftForge.EVENT_BUS).getBusID();
         // The throwaway instances exist only to reach the per-class ListenerList; their fields are never read.
-        added = new InventoryChangedEvent.ItemAdded(null, null).getListenerList();
-        removed = new InventoryChangedEvent.ItemRemoved(null, null).getListenerList();
+        added = new InventoryChangedEvent.ItemAdded(null, null, 0).getListenerList();
+        removed = new InventoryChangedEvent.ItemRemoved(null, null, 0).getListenerList();
         ready = true;
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/inventory/InventoryEventPoster.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/inventory/InventoryEventPoster.java
@@ -7,12 +7,16 @@ import net.minecraftforge.common.MinecraftForge;
 
 import com.gtnewhorizon.gtnhlib.event.InventoryChangedEvent;
 
+import it.unimi.dsi.fastutil.longs.Long2IntMap;
+
 /**
  * Reusable {@link InventoryDiffer.DeltaConsumer} that turns a packed-key delta into a posted event.
  */
 public final class InventoryEventPoster implements InventoryDiffer.DeltaConsumer {
 
     public EntityPlayer player;
+    /** Current snapshot; supplies the post-change total for each identity. */
+    public Long2IntMap current;
 
     @Override
     public void accept(long key, int delta) {
@@ -20,12 +24,13 @@ public final class InventoryEventPoster implements InventoryDiffer.DeltaConsumer
         final Item item = Item.getItemById(ItemIdentity.unpackId(key));
         if (item == null) return;
         final int meta = ItemIdentity.unpackMeta(key);
+        final int total = current.get(key);
         if (delta > 0) {
             MinecraftForge.EVENT_BUS
-                    .post(new InventoryChangedEvent.ItemAdded(player, new ItemStack(item, delta, meta)));
+                    .post(new InventoryChangedEvent.ItemAdded(player, new ItemStack(item, delta, meta), total));
         } else {
             MinecraftForge.EVENT_BUS
-                    .post(new InventoryChangedEvent.ItemRemoved(player, new ItemStack(item, -delta, meta)));
+                    .post(new InventoryChangedEvent.ItemRemoved(player, new ItemStack(item, -delta, meta), total));
         }
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/inventory/PlayerInventoryScanner.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/inventory/PlayerInventoryScanner.java
@@ -33,6 +33,7 @@ public final class PlayerInventoryScanner {
         }
 
         poster.player = player;
+        poster.current = current;
         InventoryDiffer.diff(state.previous, current, poster);
         state.swap();
     }
@@ -41,8 +42,8 @@ public final class PlayerInventoryScanner {
         accumulateArray(player.inventory.mainInventory, out);
         accumulateArray(player.inventory.armorInventory, out);
         accumulate(player.inventory.getItemStack(), out); // cursor / held stack
-        if (player.inventoryContainer instanceof ContainerPlayer) {
-            accumulateInventory(((ContainerPlayer) player.inventoryContainer).craftMatrix, out);
+        if (player.inventoryContainer instanceof ContainerPlayer container) {
+            accumulateInventory(container.craftMatrix, out);
         }
         if (Mods.BAUBLES) {
             accumulateInventory(BaublesCompat.getBaubles(player), out);


### PR DESCRIPTION
## Summary
Allows mods like Amazing Trophies and BetterQuesting to use the value for detection instead of using the added event as a trigger to do their own scan.

<img width="666" height="163" alt="image" src="https://github.com/user-attachments/assets/2090031f-d653-40f4-8749-e6142df22315" />



## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
