### PR TITLE
Add various debug logs to the model system

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLibConfig.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLibConfig.java
@@ -23,6 +23,10 @@ public class GTNHLibConfig {
     @Config.RequiresMcRestart
     public static int modelCacheSize;
 
+    @Config.Comment("Enables many log messages for the model system.")
+    @Config.DefaultBoolean(false)
+    public static boolean enableModelDebugLogs;
+
     @Config.Comment("Enables various mixins that allow blocks to dynamically change their sound.")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/loading/ModelRegistry.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/loading/ModelRegistry.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
 import com.gtnewhorizon.gtnhlib.api.BlockModelInfo;
 import com.gtnewhorizon.gtnhlib.api.IBlockModelProvider;
 import com.gtnewhorizon.gtnhlib.blockstate.core.BlockState;
@@ -29,6 +30,7 @@ import com.gtnewhorizon.gtnhlib.client.model.state.MissingState;
 import com.gtnewhorizon.gtnhlib.client.model.state.StateDeserializer;
 import com.gtnewhorizon.gtnhlib.client.model.state.StateModelMap;
 import com.gtnewhorizon.gtnhlib.client.model.unbaked.JSONModel;
+import com.gtnewhorizon.gtnhlib.client.model.unbaked.UnbakedModel;
 import com.gtnewhorizon.gtnhlib.concurrent.ThreadsafeCache;
 
 import cpw.mods.fml.common.FMLContainerHolder;
@@ -97,23 +99,46 @@ public class ModelRegistry {
             false);
 
     private static BakedModel bakeModel(BlockState state) {
+        if (GTNHLibConfig.enableModelDebugLogs) {
+            MODEL_LOGGER.info("Fetching new model for state: {}", state);
+        }
+
         final Block block = state.getBlock();
         final StateModelMap smm = getStateModelMap(block);
 
         // Caching this would be a little pointless, since an UnbakedModel here would map directly to the BakedModel
         // missing from the cache... that's why we're loading one from scratch. The JSONModel *used* by the UnbakedModel
         // will be cached, however.
-        return smm.selectModel(state).bake();
+        UnbakedModel unbakedModel = smm.selectModel(state);
+
+        if (GTNHLibConfig.enableModelDebugLogs) {
+            MODEL_LOGGER.info("Selected unbaked model for block {}: {}", block, unbakedModel);
+        }
+
+        return unbakedModel.bake();
     }
 
     private static StateModelMap getStateModelMap(Block block) {
         final var name = BlockName.fromBlock(block);
         final var stateLocation = new ResourceLoc.StateLoc(name.domain, name.name);
+        if (GTNHLibConfig.enableModelDebugLogs) {
+            MODEL_LOGGER.info("getStateModelMap: fetching state map for {}:{}", name.domain, name.name);
+        }
         return STATE_MODEL_MAP_CACHE.get(stateLocation);
     }
 
     private static JSONModel loadAndResolveJSONModel(ResourceLoc.ModelLoc loc) {
-        return loc.load(() -> MISSING_MODEL, GSON).resolveParents(JSON_MODEL_CACHE::get);
+        if (GTNHLibConfig.enableModelDebugLogs) {
+            MODEL_LOGGER.info("loadAndResolveJSONModel: {}", loc);
+        }
+
+        JSONModel jsonModel = loc.load(() -> MISSING_MODEL, GSON).resolveParents(JSON_MODEL_CACHE::get);
+
+        if (GTNHLibConfig.enableModelDebugLogs) {
+            MODEL_LOGGER.info("loadAndResolveJSONModel.jsonModel: {}", jsonModel);
+        }
+
+        return jsonModel;
     }
 
     private static final class BlockName {
@@ -143,6 +168,10 @@ public class ModelRegistry {
 
         @Override
         public void onResourceManagerReload(IResourceManager irm) {
+            if (GTNHLibConfig.enableModelDebugLogs) {
+                MODEL_LOGGER.info("Detected resource reload: reloading models");
+            }
+
             // Flush all caches, we may have new models
             BLOCKSTATE_MODEL_CACHE.clear();
             STATE_MODEL_MAP_CACHE.clear();
@@ -176,10 +205,23 @@ public class ModelRegistry {
 
                 // Skip unregistered mods
                 if (mrp instanceof FMLContainerHolder fmlch
-                        && !PERMITTED_MODIDS.contains(fmlch.getFMLContainer().getModId()))
+                        && !PERMITTED_MODIDS.contains(fmlch.getFMLContainer().getModId())) {
+                    if (GTNHLibConfig.enableModelDebugLogs) {
+                        MODEL_LOGGER.info(
+                                "loadModelInfo: skipping unregistered pack '{}'",
+                                fmlch.getFMLContainer().getModId());
+                    }
                     continue;
+                }
 
                 final var info = mrp.nhlib$gatherModelInfo(reader -> GSON.fromJson(reader, JSONModel.class));
+                if (GTNHLibConfig.enableModelDebugLogs) {
+                    MODEL_LOGGER.info(
+                            "loadModelInfo: pack '{}' contributed {} modeled blocks, {} textures",
+                            pack.getClass().getSimpleName(),
+                            info.modeledBlocks().size(),
+                            info.textureNames().size());
+                }
                 modeledBlocks.addAll(info.modeledBlocks());
                 texturesToLoad.addAll(info.textureNames());
             }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/loading/ResourceLoc.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/loading/ResourceLoc.java
@@ -15,8 +15,8 @@ import net.minecraft.util.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 
 import com.google.gson.Gson;
-import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
 import com.google.gson.JsonParseException;
+import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
 import com.gtnewhorizon.gtnhlib.client.model.state.StateModelMap;
 import com.gtnewhorizon.gtnhlib.client.model.unbaked.JSONModel;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/loading/ResourceLoc.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/loading/ResourceLoc.java
@@ -15,6 +15,7 @@ import net.minecraft.util.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 
 import com.google.gson.Gson;
+import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
 import com.gtnewhorizon.gtnhlib.client.model.state.StateModelMap;
 import com.gtnewhorizon.gtnhlib.client.model.unbaked.JSONModel;
 
@@ -23,13 +24,23 @@ public interface ResourceLoc<T> {
     default T load(Supplier<@NotNull T> defaultSrc, Gson gson) {
         final var jsonPath = new ResourceLocation(owner(), prefix() + path() + ext());
 
+        if (GTNHLibConfig.enableModelDebugLogs) {
+            MODEL_LOGGER.info(
+                    "Loading ResourceLoc: prefix='{}' owner='{}' path='{}' ext='{}' jsonPath='{}'",
+                    prefix(),
+                    owner(),
+                    path(),
+                    ext(),
+                    jsonPath);
+        }
+
         try {
             final InputStream is = Minecraft.getMinecraft().getResourceManager().getResource(jsonPath).getInputStream();
             return gson.fromJson(new InputStreamReader(is), clazz());
         } catch (JsonException e) {
-            MODEL_LOGGER.error("Failed to parse {}:{}", owner(), jsonPath.getResourcePath());
+            MODEL_LOGGER.error("Failed to parse {}:{}", owner(), jsonPath.getResourcePath(), e);
         } catch (IOException e) {
-            MODEL_LOGGER.error("Could not load {}:{}", owner(), jsonPath.getResourcePath());
+            MODEL_LOGGER.error("Could not load {}:{}", owner(), jsonPath.getResourcePath(), e);
         }
         return defaultSrc.get();
     }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/state/MonopartState.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/state/MonopartState.java
@@ -8,8 +8,8 @@ import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
 import com.google.gson.JsonParseException;
+import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
 import com.gtnewhorizon.gtnhlib.blockstate.core.BlockState;
 import com.gtnewhorizon.gtnhlib.client.model.JSONVariant;
 import com.gtnewhorizon.gtnhlib.client.model.Weighted;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/state/MonopartState.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/state/MonopartState.java
@@ -1,12 +1,14 @@
 package com.gtnewhorizon.gtnhlib.client.model.state;
 
 import static com.gtnewhorizon.gtnhlib.client.model.unbaked.MissingModel.MISSING_MODEL;
+import static com.gtnewhorizon.gtnhlib.core.GTNHLibCore.MODEL_LOGGER;
 
 import java.util.Map;
 import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
 import com.gtnewhorizon.gtnhlib.blockstate.core.BlockState;
 import com.gtnewhorizon.gtnhlib.client.model.JSONVariant;
 import com.gtnewhorizon.gtnhlib.client.model.Weighted;
@@ -35,9 +37,17 @@ public class MonopartState implements StateModelMap {
         while (iter.hasNext()) {
             final var e = iter.next();
             final var match = e.getKey();
-            if (match.matches(properties)) return new MonopartDough(e.getValue());
+            if (match.matches(properties)) {
+                if (GTNHLibConfig.enableModelDebugLogs) {
+                    MODEL_LOGGER.info("selectModel: state={} matched variant '{}'", state, match.getVariantName());
+                }
+                return new MonopartDough(e.getValue());
+            }
         }
 
+        if (GTNHLibConfig.enableModelDebugLogs) {
+            MODEL_LOGGER.info("selectModel: state={} matched no variants, returning MISSING_MODEL", state);
+        }
         return MISSING_MODEL;
     }
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/state/MultipartState.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/state/MultipartState.java
@@ -1,10 +1,13 @@
 package com.gtnewhorizon.gtnhlib.client.model.state;
 
+import static com.gtnewhorizon.gtnhlib.core.GTNHLibCore.MODEL_LOGGER;
+
 import java.util.Map;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
+import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
 import com.gtnewhorizon.gtnhlib.blockstate.core.BlockState;
 import com.gtnewhorizon.gtnhlib.client.model.BakeData;
 import com.gtnewhorizon.gtnhlib.client.model.JSONVariant;
@@ -33,6 +36,9 @@ public class MultipartState implements StateModelMap, UnbakedModel {
 
     @Override
     public BakedModel bake(BakeData data) {
+        if (GTNHLibConfig.enableModelDebugLogs) {
+            MODEL_LOGGER.info("bake: baking multipart model with {} cases", multipart.size());
+        }
         final var bread = new Object2ObjectArrayMap<Condition, BakedModel>(multipart.size());
         for (var c : multipart) {
             bread.put(c.when, new MonopartDough(c.apply).bake());

--- a/src/main/java/com/gtnewhorizon/gtnhlib/client/model/unbaked/JSONModel.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/client/model/unbaked/JSONModel.java
@@ -30,6 +30,7 @@ import org.joml.Vector3f;
 import org.joml.Vector4f;
 
 import com.google.common.base.Objects;
+import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
 import com.gtnewhorizon.gtnhlib.client.model.BakeData;
 import com.gtnewhorizon.gtnhlib.client.model.baked.BakedModel;
 import com.gtnewhorizon.gtnhlib.client.model.baked.PileOfQuads;
@@ -145,6 +146,10 @@ public class JSONModel implements UnbakedModel {
 
     @Override
     public BakedModel bake(BakeData data) {
+
+        if (GTNHLibConfig.enableModelDebugLogs) {
+            MODEL_LOGGER.info("bake: baking model {}", this);
+        }
 
         final var vRot = data.getAffineMatrix();
         final var sidedQuadStore = new HashMap<ModelQuadFacing, ArrayList<ModelQuadView>>(7);
@@ -271,9 +276,18 @@ public class JSONModel implements UnbakedModel {
             return this;
         }
 
+        if (GTNHLibConfig.enableModelDebugLogs) {
+            MODEL_LOGGER.info("resolveParents: resolving parent '{}'", parentId);
+        }
+
         // Inherit properties
         this.parent = modelLoader.apply(this.parentId).resolveParents(modelLoader);
-        if (parent instanceof MissingModel) return parent;
+        if (parent instanceof MissingModel) {
+            if (GTNHLibConfig.enableModelDebugLogs) {
+                MODEL_LOGGER.info("resolveParents: parent '{}' resolved to MissingModel, propagating", parentId);
+            }
+            return parent;
+        }
 
         if (this.elements.isEmpty()) this.elements = this.parent.elements;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/models/MixinFileResourcePack.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/models/MixinFileResourcePack.java
@@ -132,17 +132,19 @@ public abstract class MixinFileResourcePack extends AbstractResourcePack impleme
             }
         }
 
-        if (GTNHLibConfig.enableModelDebugLogs) {
-            if (this.nhlib$packFormat < PACK_FORMAT_MC_13_X) {
+        if (this.nhlib$packFormat < PACK_FORMAT_MC_13_X) {
+            if (GTNHLibConfig.enableModelDebugLogs) {
                 MODEL_LOGGER.warn(
                         "Rejecting valid model at {} because its pack.mcmeta format is too old (is {}, must be >={})",
                         resource,
                         this.nhlib$packFormat,
                         PACK_FORMAT_MC_13_X);
             }
-        }
 
-        // Reject it if it's too old.
-        return this.nhlib$packFormat < PACK_FORMAT_MC_13_X;
+            // Reject it if it's too old.
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/models/MixinFileResourcePack.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/models/MixinFileResourcePack.java
@@ -24,6 +24,7 @@ import org.spongepowered.asm.mixin.injection.At;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.gtnewhorizon.gtnhlib.GTNHLibConfig;
 import com.gtnewhorizon.gtnhlib.client.model.loading.ModelResourcePack;
 import com.gtnewhorizon.gtnhlib.client.model.loading.RPInfo;
 import com.gtnewhorizon.gtnhlib.client.model.unbaked.JSONModel;
@@ -128,6 +129,16 @@ public abstract class MixinFileResourcePack extends AbstractResourcePack impleme
 
             if (this.nhlib$packFormat == -1) {
                 this.nhlib$packFormat = 1;
+            }
+        }
+
+        if (GTNHLibConfig.enableModelDebugLogs) {
+            if (this.nhlib$packFormat < PACK_FORMAT_MC_13_X) {
+                MODEL_LOGGER.warn(
+                        "Rejecting valid model at {} because its pack.mcmeta format is too old (is {}, must be >={})",
+                        resource,
+                        this.nhlib$packFormat,
+                        PACK_FORMAT_MC_13_X);
             }
         }
 


### PR DESCRIPTION
## Summary
The model system backport previously had very few logs in it, which made debugging broken models extremely difficult. This PR just adds some log messages when a GTNHLib config is enabled.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
