### PR TITLE
Add an interface that allows blocks to render multiple AABBs when hovered over

### DIFF
--- a/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLibConfig.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/GTNHLibConfig.java
@@ -28,6 +28,10 @@ public class GTNHLibConfig {
     @Config.RequiresMcRestart
     public static boolean blockSoundMixins;
 
+    @Config.Comment("Allow blocks to show multiple AABBs when hovered over")
+    @Config.DefaultBoolean(true)
+    public static boolean enableMultipleHoverAABBs;
+
     @Config.Comment("Enable item rendering modifications to allow rendering some items as translucent")
     @Config.DefaultBoolean(true)
     public static boolean enableTranslucentItemRenders;

--- a/src/main/java/com/gtnewhorizon/gtnhlib/api/IBlockWithMultiplePreviewAABBs.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/api/IBlockWithMultiplePreviewAABBs.java
@@ -1,0 +1,17 @@
+package com.gtnewhorizon.gtnhlib.api;
+
+import java.util.List;
+
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.world.World;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+/// Implement on a [net.minecraft.block.Block] to allow it to render multiple selection boxes when looked at by the
+/// player. This is purely cosmetic and does not change the backing hitscan logic.
+public interface IBlockWithMultiplePreviewAABBs {
+
+    @SideOnly(Side.CLIENT)
+    List<AxisAlignedBB> getPreviewAABBs(World world, int x, int y, int z);
+}

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/Mixins.java
@@ -80,6 +80,9 @@ public enum Mixins implements IMixins {
                     "flowerpotcompat.MixinBOPPlant",
                     "flowerpotcompat.MixinBOPMushroom")
             .addRequiredMod(TargetMods.BIOMES_O_PLENTY)),
+    MULTIPLE_BLOCK_PREVIEW_AABBS(new MixinBuilder("Allow blocks to render multiple preview collision boxes")
+            .addClientMixins("MixinRenderGlobal_MultiplePreviewHitboxes")
+            .setApplyIf(() -> GTNHLibConfig.enableMultipleHoverAABBs).setPhase(Phase.EARLY)),
     //
     ;
 

--- a/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderGlobal_MultiplePreviewHitboxes.java
+++ b/src/main/java/com/gtnewhorizon/gtnhlib/mixins/early/MixinRenderGlobal_MultiplePreviewHitboxes.java
@@ -1,0 +1,54 @@
+package com.gtnewhorizon.gtnhlib.mixins.early;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.client.renderer.RenderGlobal;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.MovingObjectPosition;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.gtnewhorizon.gtnhlib.api.IBlockWithMultiplePreviewAABBs;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+
+@Mixin(RenderGlobal.class)
+public class MixinRenderGlobal_MultiplePreviewHitboxes {
+
+    @Shadow
+    public static void drawOutlinedBoundingBox(AxisAlignedBB p_147590_0_, int p_147590_1_) {
+        throw new UnsupportedOperationException("Implemented via mixin");
+    }
+
+    @Shadow
+    private WorldClient theWorld;
+
+    @WrapOperation(
+            method = "drawSelectionBox",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/RenderGlobal;drawOutlinedBoundingBox(Lnet/minecraft/util/AxisAlignedBB;I)V"))
+    private void gtnhlib$drawMultiHitboxes(AxisAlignedBB p_147590_0_, int p_147590_1_, Operation<Void> original,
+            @Local(name = "block") Block block, @Local(argsOnly = true, name = "p_72731_2_") MovingObjectPosition hit,
+            @Local(name = "d0") double playerX, @Local(name = "d1") double playerY,
+            @Local(name = "d2") double playerZ) {
+        if (block instanceof IBlockWithMultiplePreviewAABBs aabbs) {
+            var bbs = aabbs.getPreviewAABBs(this.theWorld, hit.blockX, hit.blockY, hit.blockZ);
+
+            if (bbs != null) {
+                for (var bb : bbs) {
+                    drawOutlinedBoundingBox(
+                            bb.expand(0.002F, 0.002F, 0.002F).getOffsetBoundingBox(-playerX, -playerY, -playerZ),
+                            -1);
+                }
+
+                return;
+            }
+        }
+
+        original.call(p_147590_0_, p_147590_1_);
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds an interface that allows Blocks to render multiple preview AABBs when hovered over. This is purely cosmetic and doesn't change the hitscan logic at all.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
